### PR TITLE
docs: relato do deploy + limitações conhecidas (issue #35)

### DIFF
--- a/docs/deploy-plan.md
+++ b/docs/deploy-plan.md
@@ -1,49 +1,56 @@
-# Plano de Deploy — Microserviços Fly.io + Neon
+# Plano de Deploy — Microservices Fly.io + Neon
 
-**Data:** 2026-08-15
+**Última atualização:** 2026-08-15
 **Issue:** #35
-**Branch:** feat/issue-35-hello-world
+**Branches:** `feat/issue-35-hello-world` → `fix/issue-35-split-microservices` → `homolog` → `main`
+
+Este documento descreve o que foi **efetivamente implementado e deployado** para o hello-world da issue #35. Ele substitui a versão inicial do plano (mais ambiciosa, com schemas por serviço e serviços internos) por um retrato fiel do que está rodando em produção hoje, incluindo as simplificações e lacunas conscientes que ficaram para trás.
 
 ---
 
-## Arquitetura
+## Arquitetura atual
 
 ```
 [Frontend - Vercel]  movecity-frontend.vercel.app
     │
     ▼
-[Gateway - Fly.io]   movecity-gateway.fly.dev  ← único público
-    │  httpx proxy + JWT validation
+[Gateway - Fly.io]   movecity-gateway.fly.dev
     │
-    ├──► movecity-auth.internal:8001         (schema: auth)
-    ├──► movecity-mobilidade.internal:8002   (schema: mobilidade)
-    └──► movecity-colaboracao.internal:8003  (schema: colaboracao)
+    ├──► movecity-auth.fly.dev
+    ├──► movecity-mobilidade.fly.dev
+    └──► movecity-colaboracao.fly.dev
               │
               ▼
-         [Neon PostgreSQL]  (4 schemas no mesmo banco)
+         [Neon PostgreSQL]  (schema público único)
 ```
+
+Os 4 serviços são apps independentes no Fly.io, cada um com seu próprio código, `Dockerfile`, `fly.toml` e `requirements.txt`. Nenhum deles ainda chama o outro (o gateway não faz proxy real — cada endpoint `/hello` é isolado). Todos são públicos.
 
 ---
 
 ## Apps Fly.io
 
-| App | Tipo | Porta | Região | Schema |
-|-----|------|-------|--------|--------|
-| `movecity-gateway` | público | 8000 | gru | gateway |
-| `movecity-auth` | interno | 8001 | gru | auth |
-| `movecity-mobilidade` | interno | 8002 | gru | mobilidade |
-| `movecity-colaboracao` | interno | 8003 | gru | colaboracao |
+| App | Porta | Região |
+|-----|-------|--------|
+| `movecity-gateway` | 8000 | gru |
+| `movecity-auth` | 8000 | gru |
+| `movecity-mobilidade` | 8000 | gru |
+| `movecity-colaboracao` | 8000 | gru |
 
 ---
 
-## Schemas PostgreSQL
+## Banco de dados
 
-| Schema | Tabela | Serviço |
-|--------|--------|---------|
-| `auth` | `test_user` | auth |
-| `mobilidade` | `test_linha` | mobilidade |
-| `colaboracao` | `test_reporte` | colaboracao |
-| `gateway` | `test_log` | gateway |
+Tudo roda no schema `public` do projeto `movecity` no Neon (região `sa-east-1`), sem separação por serviço:
+
+| Tabela | Serviço dono (por convenção) |
+|--------|-------------------------------|
+| `test_user` | auth |
+| `test_linha` | mobilidade |
+| `test_reporte` | colaboracao |
+| `test_log` | gateway |
+
+Migrations via Alembic, centralizadas em `src/backend/alembic/` — rodadas manualmente contra o Neon, não dentro dos containers do Fly.io.
 
 ---
 
@@ -60,107 +67,66 @@
 
 ---
 
-## Estrutura de Código
+## Estrutura de código
 
 ```
 src/backend/
 ├── shared/
 │   ├── __init__.py
-│   ├── config.py          # Settings compartilhadas
-│   ├── database.py        # Engine + session factory
-│   └── models/
-│       ├── __init__.py
-│       ├── base.py        # DeclarativeBase
-│       ├── auth.py        # TestUser (schema="auth")
-│       ├── mobilidade.py  # TestLinha (schema="mobilidade")
-│       ├── colaboracao.py # TestReporte (schema="colaboracao")
-│       └── gateway.py     # TestLog (schema="gateway")
+│   └── config.py          # Settings comuns aos 4 serviços
 │
-├── gateway/
+├── gateway/ auth/ mobilidade/ colaboracao/
 │   ├── Dockerfile
 │   ├── fly.toml
 │   ├── requirements.txt
 │   ├── main.py
+│   ├── routes.py
+│   ├── models/             # usados só pelo Alembic, não embarcados na imagem
 │   └── tests/
 │
-├── auth/
-│   ├── Dockerfile
-│   ├── fly.toml
-│   ├── requirements.txt
-│   ├── main.py
-│   └── tests/
-│
-├── mobilidade/
-│   ├── Dockerfile
-│   ├── fly.toml
-│   ├── requirements.txt
-│   ├── main.py
-│   └── tests/
-│
-├── colaboracao/
-│   ├── Dockerfile
-│   ├── fly.toml
-│   ├── requirements.txt
-│   ├── main.py
-│   └── tests/
-│
-└── docker-compose.yml     # Para rodar localmente
+├── models/base.py          # DeclarativeBase compartilhado (uso local/Alembic)
+├── alembic/                # migrations centralizadas
+└── requirements.txt        # superset, usado pelo CI e pelo Alembic local
 ```
+
+## CI/CD
+
+- **CI** (`.github/workflows/ci.yml`): lint de Conventional Commits + pytest + Jest, roda em todo PR para `homolog`/`main`.
+- **CD** (`.github/workflows/deploy-fly.yml`): dispara `flyctl deploy` dos 4 serviços a cada push em `homolog` ou `main` que toque `src/backend/**`. `auth`, `mobilidade` e `colaboracao` deployam em paralelo; `gateway` espera os três (`needs:`).
+- Tokens de deploy do Fly com escopo restrito a 1 app cada, guardados como secrets no repositório GitHub (`FLY_DEPLOY_TOKEN_<SERVIÇO>`).
 
 ---
 
-## Comandos de Deploy
+## Limitações conhecidas (débito técnico consciente)
 
-```bash
-# 1. Deletar app antigo
-flyctl apps destroy movecity-backend --yes
+Simplificações feitas de propósito para viabilizar o hello-world dentro do prazo, documentadas aqui para não virarem surpresa depois:
 
-# 2. Criar apps novos
-flyctl apps create movecity-gateway
-flyctl apps create movecity-auth
-flyctl apps create movecity-mobilidade
-flyctl apps create movecity-colaboracao
+1. **Sem separação de ambiente homolog/produção no backend.** `deploy-fly.yml` dispara para os *mesmos* 4 apps do Fly.io tanto em push para `homolog` quanto para `main` — não existe um conjunto de apps de homologação distinto do de produção. Um push em `homolog` sobrescreve o que está rodando em produção até o próximo push em `main`. O frontend não tem esse problema: a Vercel já gera uma URL de preview própria por branch.
+2. **Sem separação de banco por ambiente.** Um único banco Neon (`movecity`, schema `public`) atende tanto os testes locais quanto homolog e produção.
+3. **Sem separação por schema.** O plano original previa 1 schema Postgres por serviço (`auth`, `mobilidade`, `colaboracao`, `gateway`); o que existe hoje é 1 tabela de teste por serviço, todas no schema `public`.
+4. **Gateway não faz proxy de verdade.** Cada serviço expõe seu próprio `/hello` publicamente; o gateway ainda não centraliza roteamento nem validação de JWT (isso é o que a arquitetura de diagramas de sequência do projeto prevê para as User Stories futuras).
+5. **`auth`, `mobilidade` e `colaboracao` são públicos**, não internos — o plano original previa que só o `gateway` fosse exposto publicamente, com os demais acessíveis apenas via rede privada do Fly.io (`.internal`).
+6. **Migrations não rodam no CD.** O passo de `flyctl ssh console -C "alembic upgrade head"` do plano original não foi automatizado; migrations são aplicadas manualmente contra o Neon quando necessário.
 
-# 3. Configurar secrets (gateway)
-flyctl secrets set JWT_SECRET=... JWT_ALGORITHM=... JWT_EXPIRATION_MINUTES=... ENVIRONMENT=production SERVICE_NAME=gateway --app movecity-gateway
-
-# 4. Configurar secrets (auth)
-flyctl secrets set DATABASE_URL=... JWT_SECRET=... JWT_ALGORITHM=... JWT_EXPIRATION_MINUTES=... ENVIRONMENT=production SERVICE_NAME=auth --app movecity-auth
-
-# 5. Configurar secrets (mobilidade)
-flyctl secrets set DATABASE_URL=... ENVIRONMENT=production SERVICE_NAME=mobilidade --app movecity-mobilidade
-
-# 6. Configurar secrets (colaboracao)
-flyctl secrets set DATABASE_URL=... ENVIRONMENT=production SERVICE_NAME=colaboracao --app movecity-colaboracao
-
-# 7. Deploy (serviços primeiro, gateway depois)
-cd src/backend/auth && flyctl deploy --app movecity-auth
-cd src/backend/mobilidade && flyctl deploy --app movecity-mobilidade
-cd src/backend/colaboracao && flyctl deploy --app movecity-colaboracao
-cd src/backend/gateway && flyctl deploy --app movecity-gateway
-
-# 8. Rodar migrations
-flyctl ssh console --app movecity-auth -C "alembic upgrade head"
-flyctl ssh console --app movecity-mobilidade -C "alembic upgrade head"
-flyctl ssh console --app movecity-colaboracao -C "alembic upgrade head"
-flyctl ssh console --app movecity-gateway -C "alembic upgrade head"
-```
+Nenhuma dessas lacunas bloqueia o objetivo da issue #35 (validar o workflow ponta a ponta), mas precisam ser endereçadas antes de qualquer User Story real tocar em dado de usuário.
 
 ---
 
-## Verificação Final
+## Comandos de referência
 
 ```bash
+# Deploy manual de um serviço (a partir da raiz do repo)
+flyctl deploy --config src/backend/<servico>/fly.toml \
+  --dockerfile src/backend/<servico>/Dockerfile \
+  --remote-only .
+
+# Migrations (local, contra o Neon)
+cd src/backend && alembic upgrade head
+
+# Verificação
 curl https://movecity-gateway.fly.dev/health
-curl https://movecity-gateway.fly.dev/auth/hello
-curl https://movecity-gateway.fly.dev/mobilidade/hello
-curl https://movecity-gateway.fly.dev/colaboracao/hello
+curl https://movecity-gateway.fly.dev/gateway/hello
+curl https://movecity-auth.fly.dev/auth/hello
+curl https://movecity-mobilidade.fly.dev/mobilidade/hello
+curl https://movecity-colaboracao.fly.dev/colaboracao/hello
 ```
-
----
-
-## Documentação Atualizada
-
-- `AGENT.md`: Stack → Fly.io (4 microservices), não Render
-- `docs/setup-local.md`: Instruções para rodar 4 serviços localmente
-- `docs/deploy-plan.md`: Este arquivo

--- a/docs/relato-deploy-sprint0.md
+++ b/docs/relato-deploy-sprint0.md
@@ -1,0 +1,177 @@
+# Relato — Deploy do Hello World (Sprint 0 / Issue #35)
+
+**Data:** 15/08/2026
+**Issue:** [#35](https://github.com/davieduardo001/tcc-ciencia-computacao-ucb/issues/35)
+**Objetivo da issue:** validar o workflow completo de desenvolvimento do Movecity — branch → PR → review → CI → CD → deploy — usando um "hello world" real como cobaia, não uma feature de produto.
+
+Este documento registra, em ordem, tudo o que foi feito para colocar o backend (4 microservices) e o frontend no ar, incluindo os erros encontrados no caminho e como cada um foi resolvido. Serve como referência de como o workflow se comporta na prática e como material de apoio pra quem for repetir o processo em uma User Story real.
+
+---
+
+## 1. Ponto de partida
+
+O trabalho começou retomando um plano de deploy que já vinha sendo desenhado em uma sessão anterior (via OpenCode), registrado em `docs/deploy-plan.md`. O plano previa o backend dividido em 4 microservices FastAPI (`gateway`, `auth`, `mobilidade`, `colaboracao`) publicados como apps independentes no Fly.io, com banco compartilhado no Neon.
+
+[anexar imagem: estado inicial do board/todo do OpenCode antes de retomar]
+
+---
+
+## 2. Atualizar a issue #35 (Render → Fly.io)
+
+A issue #35 original citava Render como plataforma de backend. O `AGENT.md` do projeto já havia sido atualizado para Fly.io antes, então a issue estava desatualizada em relação à decisão de arquitetura vigente. Editamos objetivo, scope, stack e critérios de aceite da issue pra refletir Fly.io.
+
+[anexar imagem: issue #35 antes/depois da edição]
+
+---
+
+## 3. Provisionar o Fly.io
+
+- Destruído o app antigo `movecity-backend` (resquício de uma tentativa anterior, sem uso).
+- Criados os 4 apps novos: `movecity-gateway`, `movecity-auth`, `movecity-mobilidade`, `movecity-colaboracao`.
+
+[anexar imagem: lista de apps no dashboard do Fly.io]
+
+---
+
+## 4. Configurar secrets
+
+- `JWT_SECRET` gerado localmente (`openssl rand -hex 32`) e aplicado a `gateway`/`auth`.
+- `DATABASE_URL`: localizada a partir do projeto `movecity` já existente no Neon (via `neonctl`), não inventada — é a connection string real do banco de homologação/teste do projeto.
+- Todos os secrets aplicados via `flyctl secrets set` nos 4 apps.
+
+[anexar imagem: `flyctl secrets list` de um dos apps]
+
+---
+
+## 5. Rodar local (backend + frontend)
+
+Sem Docker disponível na máquina, o backend local foi apontado direto pro Neon (mesma `DATABASE_URL` de homologação) em vez do Postgres local do `docker-compose.yml`. Migrations aplicadas via Alembic, backend subido com `uvicorn`, frontend com `npm run dev`. Os 4 endpoints (`/gateway/hello`, `/auth/hello`, `/mobilidade/hello`, `/colaboracao/hello`) responderam localmente antes de qualquer deploy.
+
+[anexar imagem: frontend rodando em localhost mostrando status dos 4 serviços]
+
+---
+
+## 6. Descoberta: PR #39 mergeado sem review formal
+
+Ao checar o estado do PR que fecharia a issue #35, veio à tona que ele havia sido mergeado em `homolog` com **bypass da branch protection** — sem nenhuma aprovação registrada, contrariando a regra do `AGENT.md` ("PR requer aprovação — 1 reviewer mínimo. Sem exceção"). Ficou registrado explicitamente na issue #35, como nota de rastreabilidade, sem desfazer o merge (decisão consciente de quem estava testando o fluxo).
+
+[anexar imagem: histórico do PR #39 mostrando reviewDecision sem aprovação]
+
+---
+
+## 7. CI quebrado: 3 bugs encontrados e corrigidos
+
+Rodar o CI do PR #39 revelou 3 falhas, nenhuma delas no código de produto:
+
+| Job | Causa raiz | Correção |
+|---|---|---|
+| Testes Backend (pytest) | `alembic` faltando em `requirements.txt` — funcionava local só porque já estava instalado manualmente na venv | Adicionado `alembic>=1.13` ao `requirements.txt` |
+| Testes Frontend (Jest) | Zero arquivos de teste no frontend — "No tests found" | Criado `jest.config.js`, `jest.setup.js` e um teste smoke da página principal |
+| Lint / Conventional Commits | O script validava **cada linha** da mensagem de commit (corpo incluso) contra o regex, reprovando bullets do corpo e o commit de merge | Script corrigido pra validar só a primeira linha (subject) e ignorar merge commits |
+
+Aproveitamos também pra documentar na skill `criar-testes` (OpenCode) que testes devem ser comunicados via comentário na issue — não existe vínculo automático entre teste e issue no GitHub.
+
+[anexar imagem: CI verde — 3/3 checks passando no PR]
+
+---
+
+## 8. Divergência: plano de 4 apps vs. código monolito
+
+Antes de fazer qualquer deploy real, percebemos que o código mergeado no PR #39 era, na prática, **um único processo FastAPI** com 4 routers internos — não 4 serviços independentes como o `deploy-plan.md` descrevia. O `fly.toml`/`Dockerfile` únicos apontavam pro app `movecity-backend`, que já havia sido destruído no passo 3.
+
+Decisão: seguir o plano original e refatorar de verdade pra 4 microservices deployáveis, em vez de simplificar o plano pro que já existia.
+
+[anexar imagem: diagrama antes/depois — monolito vs. 4 serviços]
+
+---
+
+## 9. Refactor: 4 microservices deployáveis
+
+Nova branch `fix/issue-35-split-microservices` (a partir de `homolog`, já que o PR #39 estava fechado):
+
+- `shared/config.py`: settings comuns.
+- `gateway/`, `auth/`, `mobilidade/`, `colaboracao/`: cada um com `main.py`, `Dockerfile`, `fly.toml` e `requirements.txt` próprios.
+- Testes atualizados pra importar o `main.py` do próprio serviço, não mais um `main.py` compartilhado.
+- Validado local: os 4 serviços sobem isolados, cada um na sua porta, sem depender dos outros.
+
+PR #40 aberto, CI verde, **merge com bypass de novo** (decisão consciente, mesma lógica do passo 6 — testar o pipeline).
+
+[anexar imagem: PR #40 com CI verde]
+
+---
+
+## 10. Deploy manual — primeira subida real
+
+Antes de automatizar, validamos manualmente:
+
+```bash
+flyctl deploy --config src/backend/auth/fly.toml --dockerfile src/backend/auth/Dockerfile . --remote-only
+# repetido para mobilidade, colaboracao e gateway
+```
+
+Os 4 apps responderam em produção (`https://movecity-<serviço>.fly.dev/health` e `/<serviço>/hello`).
+
+> **Discussão paralela:** cogitamos consolidar os 4 serviços em 1 único app Fly.io (com múltiplas máquinas/process groups) pra simplificar a operação. Conclusão: o custo é o mesmo (Fly cobra por máquina, não por app), mas um app único amarra o deploy de todos os serviços numa imagem só — perde-se a independência de deploy que é o motivo de existir a separação. Mantivemos os 4 apps separados.
+
+[anexar imagem: `curl` dos 4 endpoints em produção]
+
+---
+
+## 11. CI/CD automático
+
+Criado `.github/workflows/deploy-fly.yml`: dispara `flyctl deploy` dos 4 serviços a cada push em `homolog` ou `main` que toque `src/backend/**`. `auth`, `mobilidade` e `colaboracao` deployam em paralelo; `gateway` só depois dos três (`needs:`).
+
+Tokens de deploy gerados com escopo restrito a 1 app cada (`flyctl tokens create deploy -a <app>`), guardados como secrets no GitHub — evitando usar o token pessoal de acesso total à conta Fly.io.
+
+Testado de ponta a ponta: merge do PR #40 → workflow disparou sozinho → 4/4 jobs verdes → endpoints em produção confirmados.
+
+[anexar imagem: `deploy-fly.yml` rodando com 4 jobs verdes]
+
+---
+
+## 12. Security review
+
+Revisão focada em vulnerabilidades introduzidas pelo diff (não geral): nenhum achado. Pontos verificados: secrets sempre via `env:` (nunca interpolados em `run:`), tokens com escopo mínimo, sem uso de `eval`/`exec`/`pickle`/deserialização insegura no backend.
+
+---
+
+## 13. PR para produção — primeira tentativa
+
+Aberto PR #41 (`homolog` → `main`), sem bypass dessa vez — produção de verdade. Um comentário "Revisado." foi deixado na conversa da PR, mas **não** era uma aprovação formal (o GitHub só conta reviews feitos via botão "Review changes → Approve"). A PR acabou fechada sem merge.
+
+[anexar imagem: PR #41 fechado, reviewDecision ainda REVIEW_REQUIRED]
+
+---
+
+## 14. Reabertura e aprovação formal
+
+PR reaberto, reviewer solicitada explicitamente (`gh pr edit --add-reviewer`), e o caminho certo pra aprovar (aba **Files changed** → botão **Review changes** → **Approve**) foi passado pra revisora. Dessa vez a aprovação ficou registrada de verdade (`reviewDecision: APPROVED`), e o merge para `main` foi feito sem bypass.
+
+[anexar imagem: PR #41 aprovado por @Vitoria-Albuquerque]
+
+---
+
+## 15. Deploy em produção
+
+Merge em `main` disparou o `deploy-fly.yml` de novo, agora publicando os 4 serviços "em produção" (mesmos apps/URLs — ver limitação abaixo). Endpoints reconfirmados no ar.
+
+[anexar imagem: os 4 serviços respondendo depois do merge em main]
+
+---
+
+## 16. Lacunas conhecidas (documentadas, não corrigidas)
+
+Simplificações conscientes, registradas em `docs/deploy-plan.md` e rastreadas na issue [#42](https://github.com/davieduardo001/tcc-ciencia-computacao-ucb/issues/42):
+
+- **Sem separação de ambiente no backend.** Homolog e produção usam os *mesmos* 4 apps Fly.io — um push em `homolog` sobrescreve o que está em produção. O frontend não tem esse problema (Vercel já separa preview de produção por branch).
+- Sem separação de banco por ambiente (1 projeto Neon só).
+- Sem separação por schema Postgres (tudo no `public`).
+- Gateway ainda não faz proxy real nem validação de JWT.
+- `auth`/`mobilidade`/`colaboracao` são públicos, não internos como o plano original previa.
+- Migrations não rodam automaticamente no CD — seguem manuais.
+
+---
+
+## Conclusão
+
+O objetivo da issue #35 — validar o workflow ponta a ponta — foi cumprido, incluindo os desvios do fluxo ideal (2 merges com bypass, 1 PR fechado por engano, uma review informal que não contou) registrados abertamente em vez de escondidos. O resultado é um backend de 4 microservices e um frontend rodando em produção real no Fly.io/Vercel, com CI e CD automatizados, e uma lista clara do que falta amadurecer antes de qualquer User Story tocar em dado real de usuário.


### PR DESCRIPTION
Atualiza `docs/deploy-plan.md` com a seção "Limitações conhecidas" (débito técnico rastreado na #42) e adiciona `docs/relato-deploy-sprint0.md`, passo a passo completo do deploy da issue #35 pra referência futura.


Closes #35