### PR TITLE
docs: criar boas-praticas-ia.md e atualizar guia/AGENT.md

### DIFF
--- a/.claude/commands/gerenciar-commits.md
+++ b/.claude/commands/gerenciar-commits.md
@@ -24,6 +24,7 @@ Garante que os commits sejam atômicos, sigam Conventional Commits e se encaixem
 7. **Fluxo pós-commit:** Após os commits, oriente o merge conforme o tipo de branch:
    - `feat/` ou `fix/`: merge em `homolog` → depois `homolog` em `main`
    - `docs/` ou `chore/`: merge direto em `main`
+   - Se a branch fecha uma US, lembre de comentar DoD-Sprint/DoD-Release na issue após cada merge (`AGENT.md`, seção "Critérios DOD").
 8. **Idioma:** Mensagens de commit preferencialmente em inglês ou português (PT-BR), mas a interação com o usuário sempre em **Português (PT-BR)**.
 
 ## Comandos úteis

--- a/.opencode/skills/desenvolver-us-backend/SKILL.md
+++ b/.opencode/skills/desenvolver-us-backend/SKILL.md
@@ -111,6 +111,15 @@ git push -u origin feat/issue-[numero]-[nome-curto]
 Comentar na issue da US:
 > "PR aberto: [link do PR]. Aguardando review de [nome do reviewer]."
 
+### 10. Fechar o ciclo (DoD)
+
+Não é responsabilidade só do reviewer — quem desenvolveu acompanha até o fim:
+
+- Após o merge em `homolog`, validar os critérios de aceite lá e comentar na issue: **"DoD-Sprint atendido: PR mergeado em homolog ([link]), critérios de aceite validados."**
+- Quando o PR `homolog` → `main` for mergeado, validar em produção e comentar: **"DoD-Release atendido: em produção ([link/URL]). Issue fechada."** — e fechar a issue se não tiver fechado sozinha via "Closes #XX".
+
+Critérios completos: `AGENT.md`, seção "Critérios DOD".
+
 ## Regras Obrigatórias
 
 | Regra | Detalhe |

--- a/.opencode/skills/desenvolver-us-frontend/SKILL.md
+++ b/.opencode/skills/desenvolver-us-frontend/SKILL.md
@@ -99,6 +99,15 @@ git push -u origin feat/issue-[numero]-[nome-curto]
 Comentar na issue da US:
 > "PR aberto: [link do PR]. Aguardando review de [nome do reviewer]."
 
+### 9. Fechar o ciclo (DoD)
+
+Não é responsabilidade só do reviewer — quem desenvolveu acompanha até o fim:
+
+- Após o merge em `homolog`, validar os critérios de aceite lá e comentar na issue: **"DoD-Sprint atendido: PR mergeado em homolog ([link]), critérios de aceite validados."**
+- Quando o PR `homolog` → `main` for mergeado, validar em produção e comentar: **"DoD-Release atendido: em produção ([link/URL]). Issue fechada."** — e fechar a issue se não tiver fechado sozinha via "Closes #XX".
+
+Critérios completos: `AGENT.md`, seção "Critérios DOD".
+
 ## Regras Obrigatórias
 
 | Regra | Detalhe |

--- a/.opencode/skills/review-pr/SKILL.md
+++ b/.opencode/skills/review-pr/SKILL.md
@@ -52,6 +52,11 @@ Comentar na issue da US:
 - [ ] Testes passam localmente
 - [ ] Cobertura mínima atendida (1 teste por serviço/componente)
 
+### DoD (Definition of Done)
+
+- [ ] Critérios de aceite (BDD) da US estão de fato satisfeitos pelo código, não só "parece que sim"
+- [ ] Se aprovado, quem desenvolveu sabe que precisa comentar DoD-Sprint/DoD-Release na issue depois do merge (`AGENT.md`, seção "Critérios DOD")
+
 ### Segurança
 
 - [ ] Não há senhas ou chaves expostas

--- a/AGENT.md
+++ b/AGENT.md
@@ -111,6 +111,21 @@ Regras de como agentes de IA devem operar nesse workflow (bypass, verificação,
 - [ ] Dependências mapeadas
 - [ ] Diagrama de sequência disponível
 
+### Critérios DOD (Definition of Done) — obrigatório, 2 níveis
+
+Uma US **não fecha** sem passar pelos dois níveis. Promoção pra `main` pode acontecer em lote (várias USs de uma vez), então o nível de sprint é o que garante que a US está genuinamente terminada antes do release.
+
+**DoD-Sprint** (conta como feita na sprint):
+- [ ] PR mergeado em `homolog` (aprovação formal + CI verde)
+- [ ] Critérios de aceite (cenários BDD) validados em homolog
+- [ ] Comentário na issue com o resultado
+
+**DoD-Release** (conta como entregue de verdade):
+- [ ] PR homolog → main aprovado e mergeado
+- [ ] Validado em produção (endpoint/tela real, não suposição)
+- [ ] Issue fechada
+- [ ] Documentação atualizada, se a US alterou algo documentado (arquitetura, setup, etc.)
+
 ### Agentes e Skills (opencode)
 
 | Agente | Uso |

--- a/AGENT.md
+++ b/AGENT.md
@@ -99,6 +99,9 @@ Antes de qualquer resposta, leia os arquivos abaixo para ter contexto completo d
 | **Conventional Commits** | `feat:`, `fix:`, `docs:`, `test:`, etc. |
 | **Sem Co-Authored-By** | Commits são apenas do desenvolvedor |
 | **1 US por pessoa** | Cada membro pega 1 US por sprint |
+| **Aprovação = botão Approve** | Comentário no PR não conta — só review formal via "Review changes" |
+
+Regras de como agentes de IA devem operar nesse workflow (bypass, verificação, autoria): `docs/boas-praticas-ia.md`.
 
 ### Critérios DOR (Definitivamente Pronto para Desenvolvimento)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,8 +15,9 @@ Todo o conteúdo em **Português (PT-BR)**. Commits podem ser em inglês ou PT-B
 ## Regras Obrigatórias
 
 - **NUNCA** commitar direto em `main` ou `homolog` sem confirmar com o usuário.
-- **NUNCA** incluir `Co-Authored-By` ou assinatura de agente/IA nos commits.
+- **NUNCA** incluir `Co-Authored-By` ou assinatura de agente/IA nos commits, PRs ou comentários de issue.
 - Mudanças em `docs/` e `src/` devem ser commits separados, salvo interdependência estrita.
+- Regras completas de como a IA deve operar no workflow (bypass de branch protection, o que conta como aprovação de PR, verificação antes de declarar algo pronto): `docs/boas-praticas-ia.md`.
 
 ## Fluxo de Branches
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,8 @@ Este arquivo fornece orientação ao Claude Code ao trabalhar com este repositó
 
 **Fonte de verdade:** `AGENT.md` — stack, time, arquitetura, próximos passos.
 
+**Manual completo do ciclo (backlog → deploy), explicando o porquê de cada etapa:** `docs/manual-sprint.md`.
+
 ## Idioma
 
 Todo o conteúdo em **Português (PT-BR)**. Commits podem ser em inglês ou PT-BR (Conventional Commits).

--- a/docs/boas-praticas-ia.md
+++ b/docs/boas-praticas-ia.md
@@ -1,0 +1,97 @@
+# Boas Práticas de Uso de IA no Workflow — Movecity
+
+Este documento define como agentes de IA (Claude Code, OpenCode, Gemini ou qualquer outro) devem operar dentro do workflow de desenvolvimento do Movecity. Ele não substitui o `docs/guia-contribuicao.md` (gitflow e commits) nem o `AGENT.md` (arquitetura e workflow de sprint) — complementa os dois com regras específicas de quando e como a IA pode agir, nascidas de casos reais que aconteceram no projeto.
+
+Vale para qualquer ferramenta de IA usada no repositório, não só uma específica.
+
+---
+
+## Princípio geral
+
+A IA é ferramenta, o desenvolvedor é responsável. Toda ação que a IA executa no repositório — commit, PR, comentário em issue, deploy, mudança de configuração — é feita **em nome de quem está conduzindo a sessão**, não da ferramenta. Isso tem consequências práticas nas seções abaixo.
+
+---
+
+## Autoria e atribuição
+
+- **Nunca** incluir `Co-Authored-By` ou qualquer referência a ferramentas de IA (Claude, Gemini, OpenCode, etc.) em commits, PRs ou comentários de issue.
+- Nunca comentar em issues ou PRs do GitHub dizendo que uma IA ajudou, gerou ou implementou algo — o histórico deve registrar apenas o trabalho, não a ferramenta usada para chegar lá.
+- Isso já era regra no `CLAUDE.md`; este documento só reforça o motivo: o repositório é acadêmico (TCC) e a autoria do trabalho é do time.
+
+---
+
+## O que a IA pode fazer sem perguntar
+
+Ações reversíveis, dentro do escopo já combinado com o usuário na conversa:
+
+- Ler código, rodar testes localmente, investigar bugs, rodar `git status`/`git log`/`git diff`
+- Criar/editar arquivos de código, docs e configuração
+- Criar branches, commitar, dar push em branches **não-protegidas**
+- Rodar `flyctl deploy`, `alembic upgrade`, instalar dependências, gerar secrets (tokens de escopo mínimo, nunca reaproveitar token pessoal de acesso total)
+
+## O que precisa de confirmação explícita antes de agir
+
+- **Deletar recursos em produção** (apps, bancos, branches protegidas) — mesmo que reversível via recriação, tem custo/risco real
+- **Merge de PR** — sempre perguntar antes, mesmo com CI verde
+- **Bypass de branch protection** — ver seção dedicada abaixo
+- **Editar issues/PRs de terceiros** ou mencionar pessoas do time
+- Qualquer ação fora do que foi pedido na conversa atual (não generalizar uma aprovação anterior para uma ação nova)
+
+---
+
+## Bypass de branch protection: quando e como
+
+`main` e `homolog` são protegidas por design — 1 aprovação obrigatória, CI obrigatório. Isso **não muda** por a IA estar conduzindo a sessão.
+
+Só existe uma situação em que um merge sem aprovação é aceitável: quando o próprio objetivo do trabalho é testar o workflow/CI/CD em si (como foi o caso da issue #35). Mesmo aí:
+
+1. O bypass é decisão do usuário, nunca da IA por conta própria.
+2. **Todo bypass precisa ser registrado explicitamente** — comentário na issue relevante, dizendo que houve bypass, por quê, e que normalmente isso bloquearia o merge. Rastreabilidade em primeiro lugar; não existe "bypass silencioso".
+3. Fora de um teste de workflow deliberado, bypass de branch protection não deve acontecer — nem em cenários de urgência. Se há urgência real, isso é conversa para o time, não uma decisão unilateral tomada durante a sessão.
+
+---
+
+## O que conta como aprovação de PR
+
+Lição aprendida na prática durante a issue #35: um **comentário** de texto na conversa do PR (ex.: "Revisado.", "ok pra mim") **não é uma aprovação formal** e não satisfaz a branch protection do GitHub. A única coisa que conta é um review submetido pelo botão **"Review changes" → "Approve"**, na aba **"Files changed"** do PR.
+
+Se a IA estiver aguardando aprovação e vir um comentário de texto na PR, não deve interpretar isso como sinal verde para merge — precisa confirmar se foi um review formal (`reviewDecision: APPROVED` via `gh pr view`) antes de prosseguir.
+
+---
+
+## Verificação antes de declarar algo pronto
+
+Nunca afirmar que testes passam, CI está verde, ou deploy funcionou sem checar de fato:
+
+- Rodar o comando e ler o output, não assumir pelo histórico da conversa
+- Depois de um push/merge, checar o resultado real do CI/CD (`gh run watch`, `gh pr checks`), não só assumir que vai passar porque passou local
+- Depois de um deploy, validar o endpoint de verdade (`curl`), não só confiar na saída do `flyctl deploy`
+
+Isso vale mesmo sob pressão de "roda logo" / "mete marcha" do usuário — velocidade não substitui verificação, só evita perguntas desnecessárias no meio do caminho.
+
+---
+
+## Documentar lacunas em vez de escondê-las
+
+Quando uma simplificação consciente é feita pra viabilizar um prazo (ex.: backend sem separação de ambiente homolog/produção, decisão registrada na issue #42), ela deve ser:
+
+1. Documentada no lugar certo (`docs/deploy-plan.md` ou equivalente), não só mencionada de passagem na conversa
+2. Registrada como issue de acompanhamento, se representar um risco antes de dados reais de usuário estarem envolvidos
+3. Comunicada ao usuário no momento em que a decisão é tomada, não descoberta depois
+
+Débito técnico invisível é pior que débito técnico registrado.
+
+---
+
+## Divergência entre plano e código
+
+Quando um plano de arquitetura/deploy (seja escrito por outra sessão de IA ou por uma pessoa) diverge do que o código realmente faz, a IA não deve silenciosamente escolher um lado. Deve expor a divergência ao usuário e deixar a decisão explícita: seguir o código (mais simples, já testado) ou seguir o plano (mais fiel à intenção original, mais trabalho). Foi o que aconteceu no refactor pra 4 microservices da issue #35 — o plano previa 4 apps separados, o código era um monolito; a decisão de refatorar em vez de simplificar o plano foi do usuário.
+
+---
+
+## Referências
+
+- `docs/guia-contribuicao.md` — gitflow e Conventional Commits
+- `AGENT.md` — arquitetura e workflow de sprint
+- `docs/relato-deploy-sprint0.md` — estudo de caso completo de onde essas regras vieram
+- `docs/boas-praticas-opencode.md` — uso específico do OpenCode (plan/build mode, agentes, skills)

--- a/docs/boas-praticas-ia.md
+++ b/docs/boas-praticas-ia.md
@@ -91,6 +91,7 @@ Quando um plano de arquitetura/deploy (seja escrito por outra sessão de IA ou p
 
 ## Referências
 
+- `docs/workflow-passo-a-passo.md` — o "como fazer" na prática, checklist do ciclo completo
 - `docs/guia-contribuicao.md` — gitflow e Conventional Commits
 - `AGENT.md` — arquitetura e workflow de sprint
 - `docs/relato-deploy-sprint0.md` — estudo de caso completo de onde essas regras vieram

--- a/docs/guia-contribuicao.md
+++ b/docs/guia-contribuicao.md
@@ -182,6 +182,8 @@ commit             →  tipo: descrição curta no imperativo (max 72 chars)
 | **Delete branch** | Branches feature são deletadas após merge |
 | **No force push** | Nunca fazer force push em branches protegidas |
 
+> **Atenção:** um comentário de texto no PR (ex.: "revisado", "ok pra mim") **não é aprovação**. Só conta o que for submetido via botão **"Review changes" → "Approve"**, na aba "Files changed". Verifique com `gh pr view <N> --json reviewDecision` antes de considerar um PR aprovado.
+
 ### Fluxo Completo
 
 ```

--- a/docs/guia-contribuicao.md
+++ b/docs/guia-contribuicao.md
@@ -2,6 +2,8 @@
 
 Boas-vindas ao repositório do Movecity! Este guia define as convenções de branches e commits que toda a equipe deve seguir para manter o histórico organizado e o fluxo de desenvolvimento previsível.
 
+> Procurando o passo a passo prático de ponta a ponta (branch → PR → review → deploy)? Veja `docs/workflow-passo-a-passo.md`.
+
 ---
 
 ## Fluxo de Branches

--- a/docs/manual-sprint.md
+++ b/docs/manual-sprint.md
@@ -1,0 +1,184 @@
+# Manual do Sprint Movecity — do Backlog ao Deploy
+
+Manual de referência do ciclo completo de trabalho no Movecity: desde a ideia virar item de backlog (PRD/SPEC) até o código rodando em produção. É o documento pra entender **o porquê** de cada etapa, não só o comando a digitar — os comandos e prompts práticos ficam nos documentos específicos, linkados ao longo do texto.
+
+**Para quem é:** qualquer pessoa do time (ou agente de IA operando em nome dela) que vá pegar uma User Story do zero.
+
+---
+
+## 1. Metodologia
+
+O Movecity combina duas abordagens, cada uma resolvendo um problema diferente:
+
+- **Lean Inception** (CAROLI, 2018) — usada na fase de especificação do produto, antes de qualquer código: alinhar personas, benchmarking (`docs/documento_visao.md`, seção 2.3) e a declaração de visão do produto (seção 3.2). Resolve o problema de "construir a coisa certa".
+- **Agentic Workflow** — o desenvolvimento em si é conduzido por agentes de IA (Claude Code, OpenCode) operando em nome de cada dev, seguindo as regras deste repositório. Resolve o problema de "construir rápido sem perder rastreabilidade".
+
+O restante deste manual detalha como as duas se encaixam no ciclo prático de uma sprint.
+
+---
+
+## 2. Arquitetura do sistema (resumo)
+
+Documentação completa: `docs/documento_arquitetura.md` (modelo 4+1 de Kruchten, 1994). Resumo do que todo mundo precisa saber antes de tocar em código:
+
+### 2.1 Estilo arquitetural
+
+**Microserviços com API Gateway.** Não é escolha estética — está ligado a um requisito de qualidade específico (escalabilidade independente por serviço, isolamento de falha, evolução incremental sem redesenho total). Isso se reflete direto na estrutura de pastas do backend (`gateway/`, `auth/`, `mobilidade/`, `colaboracao/`, cada um deployável e escalável separadamente).
+
+### 2.2 Camadas e o papel do Gateway
+
+```
+[Apresentação — Next.js]
+        │
+        ▼
+[API Gateway]  ← ponto único de entrada, valida JWT localmente
+        │
+        ├──► [Serviço de Autenticação]
+        ├──► [Serviço de Mobilidade]
+        └──► [Serviço de Colaboração]
+                    │
+                    ▼
+        [PostgreSQL + PostGIS / API SEMOB-GDF]
+```
+
+Regra que **nunca** pode ser ignorada em nenhum diagrama de sequência ou implementação: o Gateway valida o token JWT **localmente**, sem round-trip ao serviço de autenticação a cada requisição. Os serviços de domínio não conhecem sessão — recebem `identidadeUsuario` já validado pelo Gateway. Essa decisão existe pra não transformar o serviço de autenticação num gargalo de toda requisição do sistema.
+
+### 2.3 Decisões de stack e o porquê
+
+| Camada | Escolha | Por quê (resumo) |
+|---|---|---|
+| Frontend | Next.js 14 (App Router) + TypeScript | SSR/SSG reduz tempo de carregamento (requisito: ≤3s em 4G); tipagem estática reduz bugs |
+| Mapa | Leaflet JS + OpenStreetMap | Gratuito, sem risco de custo de API de mapa em produção |
+| Backend | FastAPI (Python 3.12) | Assíncrono, alta performance, OpenAPI automático, ecossistema geoespacial maduro (PostGIS) |
+| Banco | PostgreSQL + PostGIS (Neon serverless) | Free tier viável pro TCC, escala sozinho, suporta dado geoespacial nativamente |
+| Deploy backend | Fly.io (Docker) | Deploy simples, múltiplas regiões, sem lock-in de nuvem proprietária |
+| Deploy frontend | Vercel | Integração nativa com Next.js, preview automático por branch |
+| CI/CD | GitHub Actions | Nativo do repositório, sem custo adicional |
+| Autenticação | JWT stateless | Elimina estado de sessão no servidor; Gateway valida sem round-trip |
+
+Tabela completa com justificativas: `docs/documento_arquitetura.md`, seção 4.2.
+
+### 2.4 Requisitos não-funcionais que toda US precisa respeitar
+
+- Carregamento inicial ≤ 3s em 4G
+- Disponibilidade ≥ 99% nos horários de pico (5h–9h, 17h–20h)
+- Reporte colaborativo só confirma com ≥ 2 confirmações independentes (anti-spam/anti-fraude)
+- Dado de geolocalização tratado conforme LGPD
+
+---
+
+## 3. Do backlog à issue: PRD, SPEC e User Story
+
+Antes de qualquer linha de código, toda US precisa estar **formalizada como issue no GitHub**, com três camadas de informação separadas (não misturadas no mesmo texto):
+
+| Camada | O que contém | Onde fica |
+|---|---|---|
+| **User Story** | Formato `Como / Quero / Para` + cenários BDD (`Dado/Quando/Então`) — o valor pro usuário | Corpo principal da issue |
+| **PRD** | Objetivos de negócio, mudanças de UI, regras de negócio | Comentário separado na issue |
+| **SPEC** | Arquitetura, modelos de dados, endpoints, requisitos de performance | Comentário separado na issue |
+
+Por que separado e não tudo num texto só: cada camada tem um público e um ritmo de mudança diferente. A US raramente muda depois de escrita; a SPEC pode mudar várias vezes durante o desenvolvimento sem precisar reescrever o valor de negócio.
+
+**Como formalizar:** skill `gh-create-issue` (`.claude/commands/gh-create-issue.md`) — peça pro agente:
+
+> "Formaliza a US de [descrição] como issue, seguindo o template."
+
+Templates de referência: `docs/templates/Template_User_Stories.md` (US) e `docs/templates/template-card-sprint.md` (card de sprint).
+
+### Critérios DOR (Definitivamente Pronto pra Desenvolvimento)
+
+Uma US só entra em desenvolvimento quando:
+
+- [ ] PRD e SPEC documentados (comentários na issue)
+- [ ] Critérios de aceite definidos (BDD)
+- [ ] Estimativa de complexidade
+- [ ] Dependências mapeadas (outra US precisa terminar antes?)
+- [ ] Diagrama de sequência disponível
+
+O diagrama de sequência é a **spec técnica de execução** — descreve, seta por seta, como Gateway/Serviços/Modelos interagem pra aquele caso de uso. É o que garante que duas pessoas implementando USs diferentes sigam o mesmo padrão arquitetural (ex.: validação de JWT sempre no Gateway, nunca duplicada no serviço de domínio).
+
+---
+
+## 4. Sprint Planning
+
+1. Time se reúne (cerimônia), sprint backlog é revisado.
+2. Cada membro pega **1 US por sprint** — regra deliberada pra evitar gargalo de review (se todo mundo pegar 3 USs, o reviewer vira o gargalo do time inteiro) e manter escopo gerenciável dentro do prazo.
+3. Card de sprint criado no GitHub Projects a partir de `docs/templates/template-card-sprint.md` — tem checklist de desenvolvimento, review e deploy embutido, então serve de guia durante toda a US.
+4. Responsabilidade por épico já é fixa (ver `docs/distribuicao_us.md`) — reduz troca de contexto, cada pessoa aprofunda no domínio que já é dela.
+
+---
+
+## 5. Desenvolvimento (ciclo agêntico)
+
+Esse é o miolo prático — **não duplicado aqui**, está em `docs/workflow-passo-a-passo.md`: clonar o repo, abrir o agente, o que falar pra ele em cada etapa (ler a US, criar branch, implementar, testar, commitar, abrir PR, acompanhar CI, confirmar review formal, mergear, validar em produção).
+
+O que vale destacar aqui é a lógica por trás da ordem das etapas — por que não dá pra pular nenhuma:
+
+1. **Ler a US + diagrama antes de codar** — é "spec programming": sem isso, o código tende a divergir da arquitetura pretendida e só se descobre isso no review, tarde demais.
+2. **Testar local antes de commitar** — o CI vai rodar os mesmos testes; falhar lá é só perda de tempo (rodada de CI demora, feedback local é instantâneo).
+3. **Commit atômico, Conventional Commits** — histórico legível permite automação futura (changelog, versionamento semântico) e facilita reverter uma mudança específica sem arrastar outras.
+
+---
+
+## 6. Gitflow: a lógica dos 3 níveis
+
+```
+feat/* e fix/*   →  homolog  →  main
+docs/* e chore/* →  main (direto)
+```
+
+Por quê **3 níveis** e não 2 (branch → main direto)? Porque `feat/` e `fix/` alteram **comportamento funcional** — código que roda, que pode quebrar algo em produção. `homolog` existe como um ambiente real de staging onde essa mudança roda antes de qualquer usuário real (ou avaliador do TCC) ver — é a rede de segurança entre "compilou" e "está em produção".
+
+Por quê `docs/` e `chore/` **pulam** esse ambiente e vão direto pra `main`? Porque não alteram comportamento do sistema em produção — não tem risco funcional que uma homologação capturaria. Forçar essas mudanças a passar por `homolog` só adicionaria fricção sem benefício.
+
+Detalhes completos e comandos: `docs/guia-contribuicao.md`.
+
+### Por que 1 aprovação obrigatória, sempre
+
+Porque código sem segundo par de olhos é a fonte mais comum de bug que "parecia óbvio" pra quem escreveu. A regra não tem exceção — nem para IA, nem para urgência (ver `docs/boas-praticas-ia.md`, seção de bypass). E aprovação só conta se for formal (botão **Approve**, aba "Files changed") — um comentário de texto não satisfaz a branch protection do GitHub, por mais que pareça uma aprovação na conversa.
+
+---
+
+## 7. Uso de IA no processo
+
+Regras completas: `docs/boas-praticas-ia.md`. Os pontos que mais importam pra quem tá começando:
+
+- A IA nunca é citada como autora — commits, PRs e comentários de issue são só do desenvolvedor.
+- A IA pode implementar, testar, commitar e abrir PR sozinha; **merge sempre passa por confirmação sua**, mesmo com CI verde e aprovação.
+- Bypass de branch protection só é aceitável quando o próprio objetivo do trabalho é testar o pipeline — e precisa ficar registrado explicitamente na issue, nunca silencioso.
+- Se um plano de arquitetura divergir do código real, a IA expõe a divergência pra você decidir, não escolhe um lado sozinha.
+
+---
+
+## 8. CI/CD e Deploy
+
+- **CI** (`ci.yml`): dispara em todo PR pra `homolog`/`main` — lint de Conventional Commits, pytest, Jest. Ninguém mergeia com CI vermelho.
+- **CD** (`deploy-fly.yml` + Vercel): dispara automaticamente no push pra `homolog` ou `main` — não é passo manual, é consequência do merge.
+- **Homolog e produção usam o mesmo pipeline**, só muda a branch de destino — isso é bom (consistência) e tem uma lacuna conhecida (backend não tem apps/banco separados por ambiente ainda — ver issue [#42](https://github.com/davieduardo001/tcc-ciencia-computacao-ucb/issues/42) e `docs/deploy-plan.md`).
+
+Passo a passo prático de deploy: `docs/workflow-passo-a-passo.md`, seções 6–11.
+
+---
+
+## 9. Fechando o ciclo
+
+- Issue comentada com o resultado (PR mergeado, rodando em produção).
+- Se algo saiu diferente do planejado (débito técnico consciente, divergência de plano), isso é **documentado**, não escondido — vira uma issue de acompanhamento se representar risco antes de dado real de usuário (exemplo real: issue #42).
+- Card de sprint atualizado (checklist de `docs/templates/template-card-sprint.md`).
+- Próxima sprint: repete o ciclo a partir da seção 3.
+
+---
+
+## Mapa de documentos
+
+| Pergunta | Documento |
+|---|---|
+| Por que a arquitetura é assim? | `docs/documento_arquitetura.md` |
+| Qual o produto e pra quem? | `docs/documento_visao.md` |
+| Quem é responsável por qual US? | `docs/distribuicao_us.md` |
+| Como formalizar uma US? | `.claude/commands/gh-create-issue.md`, `docs/templates/` |
+| Como executar o ciclo com o agente, na prática? | `docs/workflow-passo-a-passo.md` |
+| Quais as regras de branch/commit e por quê? | `docs/guia-contribuicao.md` |
+| O que a IA pode/não pode fazer sozinha? | `docs/boas-praticas-ia.md` |
+| Como foi o deploy real da issue #35 (estudo de caso)? | `docs/relato-deploy-sprint0.md` |
+| Como rodar o projeto localmente? | `docs/setup-local.md` |

--- a/docs/manual-sprint.md
+++ b/docs/manual-sprint.md
@@ -160,9 +160,25 @@ Passo a passo prático de deploy: `docs/workflow-passo-a-passo.md`, seções 6�
 
 ---
 
-## 9. Fechando o ciclo
+## 9. Fechando o ciclo: DoD (Definition of Done)
 
-- Issue comentada com o resultado (PR mergeado, rodando em produção).
+Assim como existe DoR pra uma US **entrar** em desenvolvimento (seção 3), existe DoD pra ela **sair** — em 2 níveis, porque a promoção pra `main` costuma acontecer em lote (várias USs de uma vez no fim da sprint), não uma a uma:
+
+**DoD-Sprint** (conta como feita na sprint):
+- [ ] PR mergeado em `homolog` (aprovação formal + CI verde)
+- [ ] Critérios de aceite (BDD) validados em homolog
+- [ ] Comentário na issue registrando o resultado
+
+**DoD-Release** (conta como entregue de verdade):
+- [ ] PR `homolog` → `main` aprovado e mergeado
+- [ ] Validado em produção (endpoint/tela real, não suposição)
+- [ ] Issue fechada
+- [ ] Documentação atualizada, se a US alterou algo documentado
+
+Isso é **obrigatório**, não opcional — está em `AGENT.md`, seção "Critérios DOD", e as skills `desenvolver-us-backend`/`desenvolver-us-frontend` (OpenCode) já incluem o passo de comentar cada nível na issue.
+
+Outros pontos de fechamento:
+
 - Se algo saiu diferente do planejado (débito técnico consciente, divergência de plano), isso é **documentado**, não escondido — vira uma issue de acompanhamento se representar risco antes de dado real de usuário (exemplo real: issue #42).
 - Card de sprint atualizado (checklist de `docs/templates/template-card-sprint.md`).
 - Próxima sprint: repete o ciclo a partir da seção 3.

--- a/docs/templates/template-card-sprint.md
+++ b/docs/templates/template-card-sprint.md
@@ -49,17 +49,19 @@ Use este template ao criar cards no GitHub Projects para cada sprint.
 ## Após o Desenvolvimento
 
 ### Review
-- [ ] 1 reviewer aprovou o PR
+- [ ] 1 reviewer aprovou o PR (formal — botão "Approve", não comentário)
 - [ ] Testes passando no CI
 - [ ] Lint passando
 - [ ] Branch naming correta
 
-### Deploy
-- [ ] Merge para `homolog` → deploy automático (Vercel)
-- [ ] Testes de integração em homolog
-- [ ] Merge para `main` → deploy (Vercel + Fly.io)
+### DoD-Sprint (conta como feita na sprint)
+- [ ] Merge para `homolog` → deploy automático
+- [ ] Critérios de aceite (BDD) validados em homolog
+- [ ] Comentário na issue registrando o DoD-Sprint
 
-### Finalização
+### DoD-Release (conta como entregue de verdade)
+- [ ] PR `homolog` → `main` aprovado e mergeado → deploy (Vercel + Fly.io)
+- [ ] Validado em produção (endpoint/tela real)
 - [ ] Issue fechada
 - [ ] Documentação atualizada (se aplicável)
 

--- a/docs/workflow-passo-a-passo.md
+++ b/docs/workflow-passo-a-passo.md
@@ -1,0 +1,197 @@
+# Workflow Movecity — Passo a Passo
+
+Manual prático de como executar o ciclo completo de desenvolvimento no Movecity, do início de uma User Story até ela estar rodando em produção. É o "como fazer" — as regras e o porquê de cada uma estão em `docs/guia-contribuicao.md` (gitflow/commits) e `docs/boas-praticas-ia.md` (uso de IA no processo). Um estudo de caso real disso tudo acontecendo está em `docs/relato-deploy-sprint0.md`.
+
+Use este documento como checklist toda vez que for pegar uma US ou corrigir um bug.
+
+---
+
+## Visão geral do ciclo
+
+```
+1. Criar branch (a partir de homolog, pra feat/fix)
+2. Desenvolver + testar local
+3. Commit (Conventional Commits)
+4. Push + abrir PR para homolog
+5. CI roda automaticamente
+6. Pedir review → aprovação formal
+7. Merge para homolog → deploy automático de homologação
+8. Validar em homolog
+9. Abrir PR homolog → main
+10. Review + merge → deploy automático de produção
+11. Validar em produção + comentar na issue
+```
+
+---
+
+## 1. Criar a branch
+
+Sempre a partir de `homolog` atualizado (`feat/`, `fix/`) ou `main` atualizado (`docs/`, `chore/`):
+
+```bash
+git checkout homolog
+git pull origin homolog
+git checkout -b feat/issue-[numero]-[nome-curto]
+```
+
+Nomeação: kebab-case, sempre prefixado pelo tipo (`feat/`, `fix/`, `docs/`, `chore/`, `refactor/`, `test/`). Detalhes: `docs/guia-contribuicao.md`.
+
+---
+
+## 2. Desenvolver e testar localmente
+
+- Leia a issue da US e o diagrama de sequência correspondente antes de codar.
+- Implemente seguindo a estrutura de pastas do projeto.
+- Rode os testes **antes** de commitar:
+
+```bash
+# Backend
+cd src/backend && pytest -v
+
+# Frontend
+cd src/frontend && npm test
+```
+
+Não abra PR com teste falhando local — o CI vai reprovar do mesmo jeito, só que mais devagar.
+
+---
+
+## 3. Commitar
+
+```bash
+git add <arquivos>
+git commit -m "feat: descricao curta no imperativo"
+```
+
+- Um commit = uma intenção.
+- Máximo 72 caracteres na primeira linha.
+- Mudanças em `docs/` e `src/` em commits separados.
+- **Nunca** `Co-Authored-By` ou menção a ferramenta de IA.
+
+---
+
+## 4. Push e abrir o PR
+
+```bash
+git push -u origin feat/issue-[numero]-[nome-curto]
+gh pr create --base homolog --title "..." --body "..."
+```
+
+Preencha o template do PR (checklist + "Closes #[numero]" se a US for fechada por esse PR).
+
+[anexar imagem: tela de abertura de PR no GitHub com o template preenchido]
+
+---
+
+## 5. Acompanhar o CI
+
+O CI (`ci.yml`) dispara sozinho no PR: lint de commits, pytest, Jest. Acompanhe com:
+
+```bash
+gh pr checks <numero>
+# ou, pra assistir em tempo real:
+gh run watch <run-id>
+```
+
+Se algo falhar, corrija e dê push de novo na mesma branch — o CI roda de novo automaticamente.
+
+[anexar imagem: aba "Checks" do PR com os 3 jobs verdes]
+
+---
+
+## 6. Pedir review e obter aprovação formal
+
+Peça review a 1 pessoa do time (`gh pr edit <numero> --add-reviewer <usuario>` ajuda a formalizar o pedido).
+
+**Importante:** só conta como aprovação o que for submetido pelo botão certo. Um comentário de texto ("revisado", "ok pra mim") não desbloqueia o merge.
+
+Caminho pra quem for aprovar:
+1. Abrir o PR
+2. Ir na aba **"Files changed"** (não em "Conversation")
+3. Rolar até o fim da página
+4. Clicar em **"Review changes"**
+5. Selecionar **"Approve"** → **"Submit review"**
+
+[anexar imagem: aba Files changed com o botão "Review changes" em destaque]
+
+[anexar imagem: dialog de review com a opção "Approve" selecionada]
+
+Confirme a aprovação formal antes de mergear:
+
+```bash
+gh pr view <numero> --json reviewDecision -q .reviewDecision
+# precisa retornar: APPROVED
+```
+
+---
+
+## 7. Merge para homolog
+
+Com CI verde e `reviewDecision: APPROVED`, mergeie (squash, pra manter o histórico limpo):
+
+```bash
+gh pr merge <numero> --squash
+```
+
+Isso dispara o deploy automático de homologação (frontend na Vercel, backend no Fly.io — se o PR tocou em `src/backend/**`).
+
+[anexar imagem: workflow de deploy rodando após o merge]
+
+---
+
+## 8. Validar em homolog
+
+Confirme que o que subiu funciona de verdade antes de prosseguir pra produção:
+
+```bash
+curl https://movecity-gateway.fly.dev/health
+# e os endpoints relevantes da sua US
+```
+
+Para o frontend, a Vercel gera uma URL de preview própria por branch — use ela pra validar visualmente.
+
+---
+
+## 9. Abrir PR homolog → main
+
+Quando o conjunto de mudanças em `homolog` estiver validado e pronto pra ir pra produção:
+
+```bash
+gh pr create --base main --head homolog --title "..." --body "..."
+```
+
+Mesmas regras do passo 6: precisa de aprovação formal, CI precisa passar.
+
+---
+
+## 10. Merge para main
+
+```bash
+gh pr merge <numero> --squash
+```
+
+Dispara o deploy automático de produção.
+
+[anexar imagem: os serviços respondendo em produção após o merge]
+
+---
+
+## 11. Validar e fechar o ciclo
+
+- Confirme os endpoints/telas em produção.
+- Comente na issue da US com o resultado (`"PR mergeado: [link]. Rodando em produção."`).
+- Se a issue não fechou automaticamente via "Closes #XX", feche manualmente.
+
+---
+
+## Checklist rápido
+
+- [ ] Branch criada a partir da base certa
+- [ ] Testes passando local antes do commit
+- [ ] Commits seguem Conventional Commits, sem menção a IA
+- [ ] PR aberto com template preenchido
+- [ ] CI verde
+- [ ] Review **formal** (`reviewDecision: APPROVED`), não só comentário
+- [ ] Merge → validado em homolog
+- [ ] PR homolog → main → validado em produção
+- [ ] Issue comentada/fechada

--- a/docs/workflow-passo-a-passo.md
+++ b/docs/workflow-passo-a-passo.md
@@ -1,197 +1,173 @@
-# Workflow Movecity — Passo a Passo
+# Workflow Movecity — Passo a Passo (com Agente de IA)
 
-Manual prático de como executar o ciclo completo de desenvolvimento no Movecity, do início de uma User Story até ela estar rodando em produção. É o "como fazer" — as regras e o porquê de cada uma estão em `docs/guia-contribuicao.md` (gitflow/commits) e `docs/boas-praticas-ia.md` (uso de IA no processo). Um estudo de caso real disso tudo acontecendo está em `docs/relato-deploy-sprint0.md`.
+Manual prático de como executar o ciclo completo de desenvolvimento no Movecity **usando um agente de IA** (Claude Code ou OpenCode) — do clone do repositório até a US rodando em produção. O trabalho é agêntico: você não digita `git`/`gh` na mão, você diz pro agente o que precisa e confere o que ele fez.
 
-Use este documento como checklist toda vez que for pegar uma US ou corrigir um bug.
-
----
-
-## Visão geral do ciclo
-
-```
-1. Criar branch (a partir de homolog, pra feat/fix)
-2. Desenvolver + testar local
-3. Commit (Conventional Commits)
-4. Push + abrir PR para homolog
-5. CI roda automaticamente
-6. Pedir review → aprovação formal
-7. Merge para homolog → deploy automático de homologação
-8. Validar em homolog
-9. Abrir PR homolog → main
-10. Review + merge → deploy automático de produção
-11. Validar em produção + comentar na issue
-```
+As regras e o porquê de cada uma estão em `docs/guia-contribuicao.md` (gitflow/commits) e `docs/boas-praticas-ia.md` (o que o agente pode fazer sozinho vs. precisa de confirmação sua). Um estudo de caso real disso tudo acontecendo está em `docs/relato-deploy-sprint0.md`.
 
 ---
 
-## 1. Criar a branch
-
-Sempre a partir de `homolog` atualizado (`feat/`, `fix/`) ou `main` atualizado (`docs/`, `chore/`):
+## 0. Clonar o repositório e abrir o agente
 
 ```bash
-git checkout homolog
-git pull origin homolog
-git checkout -b feat/issue-[numero]-[nome-curto]
+git clone https://github.com/davieduardo001/tcc-ciencia-computacao-ucb.git
+cd tcc-ciencia-computacao-ucb
 ```
 
-Nomeação: kebab-case, sempre prefixado pelo tipo (`feat/`, `fix/`, `docs/`, `chore/`, `refactor/`, `test/`). Detalhes: `docs/guia-contribuicao.md`.
+Abra o agente **de dentro dessa pasta** — o contexto do projeto (`CLAUDE.md`/`AGENT.md` pro Claude Code, `opencode.json`/`.opencode/` pro OpenCode) é carregado automaticamente porque ele lê os arquivos do repositório.
+
+| Ferramenta | Como abrir |
+|---|---|
+| Claude Code | `claude` no terminal |
+| OpenCode | `opencode` no terminal |
+
+Na primeira mensagem, o agente já sabe: quem é o time, qual sua US (se você disser o número), a arquitetura, as regras de commit/branch. Não precisa colar contexto — só pedir.
 
 ---
 
-## 2. Desenvolver e testar localmente
+## 1. Pegar uma US
 
-- Leia a issue da US e o diagrama de sequência correspondente antes de codar.
-- Implemente seguindo a estrutura de pastas do projeto.
-- Rode os testes **antes** de commitar:
+Fale com o agente:
 
-```bash
-# Backend
-cd src/backend && pytest -v
+> "Lê a issue #23 e me explica o que precisa ser feito."
 
-# Frontend
-cd src/frontend && npm test
-```
-
-Não abra PR com teste falhando local — o CI vai reprovar do mesmo jeito, só que mais devagar.
+Ele vai buscar a issue no GitHub (`gh issue view`), ler o diagrama de sequência correspondente em `docs/diagramas/sequencia/` e te devolver um resumo. É o momento de tirar dúvida antes de qualquer código ser escrito — no Claude Code, isso normalmente entra em modo de planejamento; no OpenCode, é o **Plan Mode**.
 
 ---
 
-## 3. Commitar
+## 2. Criar a branch
+
+> "Cria a branch pra US #23."
+
+O que o agente executa por baixo:
 
 ```bash
-git add <arquivos>
-git commit -m "feat: descricao curta no imperativo"
+git checkout homolog && git pull origin homolog
+git checkout -b feat/issue-23-reportar-ocorrencia
 ```
 
-- Um commit = uma intenção.
-- Máximo 72 caracteres na primeira linha.
-- Mudanças em `docs/` e `src/` em commits separados.
-- **Nunca** `Co-Authored-By` ou menção a ferramenta de IA.
+Confirme que o nome da branch bate com o padrão (`feat/issue-[numero]-[nome-curto]`) antes de seguir.
 
 ---
 
-## 4. Push e abrir o PR
+## 3. Implementar
+
+> "Implementa a US #23 seguindo o diagrama de sequência."
+
+O agente vai criar/editar os arquivos necessários (endpoints, models, componentes). **Revise o que ele fez antes de aprovar** — peça pra ele te mostrar o diff (`git diff`) ou explicar as mudanças se algo não ficou claro. Você é quem confirma que o código faz sentido, não só que "rodou".
+
+---
+
+## 4. Testar
+
+> "Roda os testes."
+
+O agente executa `pytest -v` (backend) e/ou `npm test` (frontend) e te mostra o resultado real — não aceite um "deve estar passando", peça o output.
+
+Se algo falhar, peça pra ele investigar e corrigir antes de seguir pro commit.
+
+---
+
+## 5. Commitar
+
+> "Commita seguindo Conventional Commits."
+
+O agente monta a mensagem (`feat:`, `fix:`, etc.), separa `docs/` de `src/` se for o caso, e **nunca** inclui `Co-Authored-By` ou menção a ferramenta de IA — isso é regra fixa, não precisa pedir.
+
+---
+
+## 6. Abrir o PR
+
+> "Sobe a branch e abre o PR pra homolog."
 
 ```bash
-git push -u origin feat/issue-[numero]-[nome-curto]
+git push -u origin feat/issue-23-reportar-ocorrencia
 gh pr create --base homolog --title "..." --body "..."
 ```
 
-Preencha o template do PR (checklist + "Closes #[numero]" se a US for fechada por esse PR).
+O agente preenche o template do PR e referencia a issue (`Closes #23`).
 
 [anexar imagem: tela de abertura de PR no GitHub com o template preenchido]
 
 ---
 
-## 5. Acompanhar o CI
+## 7. Acompanhar o CI
 
-O CI (`ci.yml`) dispara sozinho no PR: lint de commits, pytest, Jest. Acompanhe com:
+> "Acompanha o CI do PR e me avisa se passar ou falhar."
 
-```bash
-gh pr checks <numero>
-# ou, pra assistir em tempo real:
-gh run watch <run-id>
-```
-
-Se algo falhar, corrija e dê push de novo na mesma branch — o CI roda de novo automaticamente.
+O agente roda `gh pr checks`/`gh run watch` e reporta o resultado real, não assume. Se falhar, ele investiga a causa antes de propor correção — não sai chutando fix.
 
 [anexar imagem: aba "Checks" do PR com os 3 jobs verdes]
 
 ---
 
-## 6. Pedir review e obter aprovação formal
+## 8. Pedir review (humano) e confirmar aprovação
 
-Peça review a 1 pessoa do time (`gh pr edit <numero> --add-reviewer <usuario>` ajuda a formalizar o pedido).
+Review é etapa humana — peça pra 1 pessoa do time revisar o PR. Passe esse caminho pra quem for aprovar:
 
-**Importante:** só conta como aprovação o que for submetido pelo botão certo. Um comentário de texto ("revisado", "ok pra mim") não desbloqueia o merge.
+1. Abrir o PR → aba **"Files changed"** (não "Conversation")
+2. Rolar até o fim → **"Review changes"** → **"Approve"** → **"Submit review"**
 
-Caminho pra quem for aprovar:
-1. Abrir o PR
-2. Ir na aba **"Files changed"** (não em "Conversation")
-3. Rolar até o fim da página
-4. Clicar em **"Review changes"**
-5. Selecionar **"Approve"** → **"Submit review"**
+Um comentário de texto ("revisado", "ok") **não conta**. Depois, peça pro agente confirmar de verdade:
+
+> "Confirma se o PR #23 já foi aprovado formalmente."
+
+Ele checa `reviewDecision` via `gh pr view` — só segue se vier `APPROVED`.
 
 [anexar imagem: aba Files changed com o botão "Review changes" em destaque]
 
-[anexar imagem: dialog de review com a opção "Approve" selecionada]
-
-Confirme a aprovação formal antes de mergear:
-
-```bash
-gh pr view <numero> --json reviewDecision -q .reviewDecision
-# precisa retornar: APPROVED
-```
-
 ---
 
-## 7. Merge para homolog
+## 9. Merge para homolog
 
-Com CI verde e `reviewDecision: APPROVED`, mergeie (squash, pra manter o histórico limpo):
+> "Pode mergear o PR #23."
 
-```bash
-gh pr merge <numero> --squash
-```
+O agente **deve confirmar com você antes de mergear**, mesmo com CI verde e aprovação — isso é regra (`docs/boas-praticas-ia.md`). Ele nunca decide sozinho bypassar a branch protection; se isso for necessário, é decisão sua, explícita, registrada na issue.
 
-Isso dispara o deploy automático de homologação (frontend na Vercel, backend no Fly.io — se o PR tocou em `src/backend/**`).
+O merge dispara o deploy automático de homologação (Vercel + Fly.io, se tocou em `src/backend/**`).
 
 [anexar imagem: workflow de deploy rodando após o merge]
 
 ---
 
-## 8. Validar em homolog
+## 10. Validar em homolog
 
-Confirme que o que subiu funciona de verdade antes de prosseguir pra produção:
+> "Confirma que os endpoints da US #23 estão respondendo em homolog."
 
-```bash
-curl https://movecity-gateway.fly.dev/health
-# e os endpoints relevantes da sua US
-```
-
-Para o frontend, a Vercel gera uma URL de preview própria por branch — use ela pra validar visualmente.
+O agente valida de verdade (`curl`, não só "o deploy deve ter funcionado"). Para telas, use a URL de preview que a Vercel gera por branch.
 
 ---
 
-## 9. Abrir PR homolog → main
+## 11. PR homolog → main e produção
 
-Quando o conjunto de mudanças em `homolog` estiver validado e pronto pra ir pra produção:
+Mesmo ciclo dos passos 6 a 10, trocando a base do PR pra `main`:
 
-```bash
-gh pr create --base main --head homolog --title "..." --body "..."
-```
+> "Abre o PR de homolog pra main."
 
-Mesmas regras do passo 6: precisa de aprovação formal, CI precisa passar.
-
----
-
-## 10. Merge para main
-
-```bash
-gh pr merge <numero> --squash
-```
-
-Dispara o deploy automático de produção.
+Mesmas regras: CI verde, aprovação formal, confirmação sua antes do merge.
 
 [anexar imagem: os serviços respondendo em produção após o merge]
 
 ---
 
-## 11. Validar e fechar o ciclo
+## 12. Fechar o ciclo
 
-- Confirme os endpoints/telas em produção.
-- Comente na issue da US com o resultado (`"PR mergeado: [link]. Rodando em produção."`).
-- Se a issue não fechou automaticamente via "Closes #XX", feche manualmente.
+> "Comenta na issue #23 que foi pra produção."
+
+O agente comenta o resultado na issue (sem mencionar que uma IA fez o trabalho — só o resultado). Se a issue não fechou sozinha via "Closes #23", peça pra fechar manualmente.
 
 ---
 
 ## Checklist rápido
 
+- [ ] Repositório clonado, agente aberto de dentro da pasta
+- [ ] Issue e diagrama de sequência lidos antes de codar
 - [ ] Branch criada a partir da base certa
-- [ ] Testes passando local antes do commit
+- [ ] Código revisado por você, não só "rodou"
+- [ ] Testes passando local (output real, não suposição)
 - [ ] Commits seguem Conventional Commits, sem menção a IA
 - [ ] PR aberto com template preenchido
 - [ ] CI verde
 - [ ] Review **formal** (`reviewDecision: APPROVED`), não só comentário
-- [ ] Merge → validado em homolog
-- [ ] PR homolog → main → validado em produção
+- [ ] Agente pediu sua confirmação antes de cada merge
+- [ ] Validado em homolog e em produção de verdade (curl/tela), não por suposição
 - [ ] Issue comentada/fechada


### PR DESCRIPTION
Documento novo `docs/boas-praticas-ia.md`, tool-agnóstico (vale pra Claude Code, OpenCode ou qualquer outra IA), cobrindo:

- Autoria/atribuição (reforça regra existente)
- O que a IA pode fazer sem perguntar vs. precisa de confirmação
- Bypass de branch protection: quando é aceitável e como registrar
- O que conta como aprovação de PR (comentário ≠ approve — lição da issue #35)
- Verificação antes de declarar algo pronto
- Documentar lacunas em vez de esconder
- Divergência entre plano e código

Também atualiza `CLAUDE.md`, `AGENT.md` e `docs/guia-contribuicao.md` com pointers pro novo doc e a nuance de aprovação formal.

Relacionado à issue #35 (não fecha — é documentação derivada do que aprendemos lá).

Relacionado a #36 (Workflow e Padronização dos Agentes) e #37 (Gitflow e Boas Práticas de Branch).
