### PR TITLE
fix: CI sempre roda no PR, mesmo em mudancas docs-only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,6 @@ name: CI — Testes no PR
 on:
   pull_request:
     branches: [homolog, main]
-    paths:
-      - "src/**"
-      - ".github/workflows/ci.yml"
 
   workflow_dispatch:
 


### PR DESCRIPTION
Bug encontrado hoje: `ci.yml` só disparava quando o PR tocava em `src/**`. Como a branch protection marca Lint/pytest/Jest como **obrigatórios** pra qualquer PR, PRs docs-only (#43, #44) ficavam com esses checks presos em "Expected — Waiting for status to be reported" pra sempre — mesmo aprovados, o merge nunca destravava.

Correção: remove o filtro de `paths`, o CI roda sempre. Custo: alguns segundos a mais de CI em PRs que só tocam `docs/`, aceitável.

Relacionado a #37 (Gitflow e Boas Práticas de Branch).
