### PR TITLE
feat: adicionar endpoint teste-vitoria no servico colaboracao

### DIFF
--- a/src/backend/colaboracao/routes.py
+++ b/src/backend/colaboracao/routes.py
@@ -6,3 +6,8 @@ router = APIRouter()
 @router.get("/hello")
 def hello():
     return {"service": "colaboracao", "status": "ok"}
+
+
+@router.get("/teste-vitoria")
+def teste_vitoria():
+    return {"service": "colaboracao", "autor": "Vitoria-Albuquerque", "mensagem": "hello world"}

--- a/src/backend/colaboracao/tests/test_teste_vitoria.py
+++ b/src/backend/colaboracao/tests/test_teste_vitoria.py
@@ -1,0 +1,16 @@
+from fastapi.testclient import TestClient
+
+from colaboracao.main import app
+
+client = TestClient(app)
+
+
+def test_teste_vitoria():
+    response = client.get("/colaboracao/teste-vitoria")
+    assert response.status_code == 200
+    data = response.json()
+    assert data == {
+        "service": "colaboracao",
+        "autor": "Vitoria-Albuquerque",
+        "mensagem": "hello world",
+    }


### PR DESCRIPTION
## Descrição

Adiciona o endpoint `GET /colaboracao/teste-vitoria` no serviço `colaboracao`, seguindo o mesmo padrão do endpoint `/hello` já existente. Exercício de workflow (issue #48) — validar o ciclo completo branch → PR → review → CI → CD → DoD.

## Tipo de mudança

- [x] Nova feature (`feat/`)

## Issue vinculada

Closes #48

## Como testar

1. `cd src/backend && pip install -r requirements.txt`
2. `uvicorn colaboracao.main:app --reload` (ou rodar via CI)
3. `GET /colaboracao/teste-vitoria` deve retornar `200` com `{"service": "colaboracao", "autor": "Vitoria-Albuquerque", "mensagem": "hello world"}`
4. `cd src/backend && pytest -v --tb=short` — todos os testes (incluindo os já existentes dos outros serviços) continuam passando

## Screenshots (se aplicável)

N/A — endpoint de API, sem interface.

## Checklist

- [x] Branch nomeada corretamente (`feat/issue-48-teste-vitoria`)
- [x] Commits seguem Conventional Commits
- [x] Testes unitários passando
- [x] Sem referências a IA (Claude, Gemini, etc.) nos commits
- [x] Descrição completa do PR
- [x] Issue vinculada no PR

## Notas adicionais

Testado localmente com `pytest -v --tb=short` a partir de `src/backend` (mesmo working dir usado pelo CI): 5 passed, sem regressão nos testes existentes.



Closes #48