### PR TITLE
chore: adicionar pipeline de deploy do frontend na Vercel

### DIFF
--- a/.github/workflows/deploy-vercel.yml
+++ b/.github/workflows/deploy-vercel.yml
@@ -1,0 +1,72 @@
+name: Deploy Frontend (Vercel)
+
+on:
+  push:
+    branches: [homolog, main]
+    paths:
+      - "src/frontend/**"
+      - ".github/workflows/deploy-vercel.yml"
+  workflow_dispatch:
+
+jobs:
+  deploy-homolog:
+    name: Deploy Homolog (Preview)
+    if: github.ref == 'refs/heads/homolog'
+    runs-on: ubuntu-latest
+    concurrency:
+      group: deploy-vercel-homolog
+      cancel-in-progress: false
+    defaults:
+      run:
+        working-directory: src/frontend
+    env:
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Instalar Vercel CLI
+        run: npm install --global vercel@latest
+
+      - name: Puxar configuração do ambiente (Preview)
+        run: vercel pull --yes --environment=preview --token=$VERCEL_TOKEN
+
+      - name: Build do projeto
+        run: vercel build --token=$VERCEL_TOKEN
+
+      - name: Deploy (Preview)
+        id: deploy
+        run: echo "url=$(vercel deploy --prebuilt --token=$VERCEL_TOKEN)" >> "$GITHUB_OUTPUT"
+
+      - name: Apontar alias fixo de homolog
+        run: vercel alias set "${{ steps.deploy.outputs.url }}" movecity-frontend-homolog.vercel.app --token=$VERCEL_TOKEN
+
+  deploy-producao:
+    name: Deploy Produção
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    concurrency:
+      group: deploy-vercel-producao
+      cancel-in-progress: false
+    defaults:
+      run:
+        working-directory: src/frontend
+    env:
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Instalar Vercel CLI
+        run: npm install --global vercel@latest
+
+      - name: Puxar configuração do ambiente (Production)
+        run: vercel pull --yes --environment=production --token=$VERCEL_TOKEN
+
+      - name: Build do projeto
+        run: vercel build --prod --token=$VERCEL_TOKEN
+
+      - name: Deploy (Production)
+        run: vercel deploy --prebuilt --prod --token=$VERCEL_TOKEN

--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,4 @@ Thumbs.db
 # ============================
 *.log
 npm-debug.log*
+.env*


### PR DESCRIPTION
﻿## Descrição

Adiciona pipeline de deploy do frontend (`src/frontend`) na Vercel via GitHub Actions, substituindo o deploy automático da integração Git nativa da Vercel:
- Push em `homolog` -> build e deploy no ambiente Preview, com alias fixo `movecity-frontend-homolog.vercel.app`
- Push em `main` -> build e deploy em Production

## Tipo de mudança

- [ ] Nova feature (`feat/`)
- [ ] Correção de bug (`fix/`)
- [ ] Documentação (`docs/`)
- [x] Configuração (`chore/`)
- [ ] Refatoração (`refactor/`)
- [ ] Testes (`test/`)

## Issue vinculada

N/A

## Como testar

1. Secrets `VERCEL_TOKEN`, `VERCEL_ORG_ID` e `VERCEL_PROJECT_ID` já configurados no repo
2. Desconectar a integração Git nativa da Vercel em Project Settings -> Git (evita deploy duplicado)
3. Após o merge, acompanhar a run do workflow "Deploy Frontend (Vercel)" na aba Actions
4. Conferir se `movecity-frontend-homolog.vercel.app` sobe corretamente