### PR TITLE
fix: rodar comandos da Vercel CLI a partir da raiz do repo

### DIFF
--- a/.github/workflows/deploy-vercel.yml
+++ b/.github/workflows/deploy-vercel.yml
@@ -16,9 +16,6 @@ jobs:
     concurrency:
       group: deploy-vercel-homolog
       cancel-in-progress: false
-    defaults:
-      run:
-        working-directory: src/frontend
     env:
       VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
@@ -37,7 +34,9 @@ jobs:
 
       - name: Deploy (Preview)
         id: deploy
-        run: echo "url=$(vercel deploy --prebuilt --token=$VERCEL_TOKEN)" >> "$GITHUB_OUTPUT"
+        run: |
+          url=$(vercel deploy --prebuilt --token=$VERCEL_TOKEN)
+          echo "url=$url" >> "$GITHUB_OUTPUT"
 
       - name: Apontar alias fixo de homolog
         run: vercel alias set "${{ steps.deploy.outputs.url }}" movecity-frontend-homolog.vercel.app --token=$VERCEL_TOKEN
@@ -49,9 +48,6 @@ jobs:
     concurrency:
       group: deploy-vercel-producao
       cancel-in-progress: false
-    defaults:
-      run:
-        working-directory: src/frontend
     env:
       VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}


### PR DESCRIPTION
## Descrição

Corrige o pipeline de deploy do frontend (#54), que quebrou em homolog logo apos o merge.

O `vercel deploy` estava rodando de dentro de `src/frontend`, mas o projeto na Vercel tem Root Directory = `src/frontend`. A CLI soma os dois e procurava `src/frontend/src/frontend` (inexistente), falhando o build/deploy. Alem disso, o erro estava sendo mascarado: `echo "url=$(vercel deploy ...)"` engolia o exit code da falha, deixando a URL vazia e quebrando o passo seguinte de alias.

## Tipo de mudança

- [ ] Nova feature (`feat/`)
- [x] Correção de bug (`fix/`)
- [ ] Documentação (`docs/`)
- [ ] Configuração (`chore/`)
- [ ] Refatoração (`refactor/`)
- [ ] Testes (`test/`)

## Issue vinculada

Segue #54

## Como testar

1. Merge nesta branch
2. Acompanhar a run do workflow "Deploy Frontend (Vercel)" em Actions
3. Confirmar que `vercel build`/`vercel deploy` acham `src/frontend` corretamente e que `movecity-frontend-homolog.vercel.app` sobe
