### PR TITLE
fix: adicionar python-jose ao requirements do gateway

### DIFF
--- a/src/backend/gateway/requirements.txt
+++ b/src/backend/gateway/requirements.txt
@@ -2,3 +2,4 @@ fastapi>=0.115.0
 uvicorn[standard]>=0.30.0
 pydantic>=2.0
 pydantic-settings>=2.0
+python-jose[cryptography]>=3.3


### PR DESCRIPTION
## Correção

Adiciona `python-jose[cryptography]` ao `requirements.txt` do Gateway.

**Problema:** Deploy falhou com `ModuleNotFoundError: No module named 'jose'`

**Causa:** O `jwt_validator.py` importa `from jose import JWTError, jwt`, mas a dependência não estava no requirements do Gateway.

**Solução:** Adicionar `python-jose[cryptography]>=3.3` ao `gateway/requirements.txt`.