### PR TITLE
fix: health check e verificacao pre-deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,25 @@ jobs:
           cd src/backend
           pip install -r requirements.txt
 
+      - name: Verificar dependências
+        run: |
+          cd src/backend
+          pip install -r gateway/requirements.txt --dry-run
+
+      - name: Verificar imports
+        run: |
+          cd src/backend
+          python -c "from gateway.main import app; print('Gateway imports OK')"
+          python -c "from auth.main import app; print('Auth imports OK')"
+
+      - name: Health check
+        run: |
+          cd src/backend
+          uvicorn gateway.main:app --host 0.0.0.0 --port 8000 &
+          sleep 3
+          curl -sf http://localhost:8000/health || exit 1
+          kill %1 || true
+
       - name: Rodar migrations
         run: |
           cd src/backend

--- a/.opencode/agents/dev-environment.md
+++ b/.opencode/agents/dev-environment.md
@@ -1,7 +1,6 @@
 ---
 description: Gerencia infraestrutura local: Docker, migrations, dependências. NÃO edita código.
 mode: subagent
-model: anthropic/claude-sonnet-4-20250514
 temperature: 0.1
 steps: 10
 permissions:

--- a/.opencode/skills/desenvolver-us-backend/SKILL.md
+++ b/.opencode/skills/desenvolver-us-backend/SKILL.md
@@ -85,6 +85,26 @@ pytest
 - Cada serviço deve ter pelo menos 1 teste passando
 - Testar cenário principal e cenários alternativos (alt/else do diagrama)
 
+### 6.1. Verificar Localmente (ANTES de commitar)
+
+```bash
+# Testar se imports funcionam
+cd src/backend
+python -c "from gateway.main import app; print('Gateway OK')"
+
+# Rodar testes
+pytest -v
+
+# Verificar health check (com backend rodando)
+curl http://localhost:8000/health
+```
+
+**Verificar:**
+- [ ] Imports funcionam
+- [ ] Testes passam
+- [ Health check retorna 200 (não 401)
+- [ ] Requirements.txt está completo
+
 ### 7. Commitar
 
 ```bash

--- a/.opencode/skills/desenvolver-us-backend/SKILL.md
+++ b/.opencode/skills/desenvolver-us-backend/SKILL.md
@@ -88,21 +88,20 @@ pytest
 ### 6.1. Verificar Localmente (ANTES de commitar)
 
 ```bash
-# Testar se imports funcionam
+# Opção rápida: rodar script de verificação
+./scripts/verificar-deploy.sh
+
+# Ou manualmente:
 cd src/backend
 python -c "from gateway.main import app; print('Gateway OK')"
-
-# Rodar testes
 pytest -v
-
-# Verificar health check (com backend rodando)
 curl http://localhost:8000/health
 ```
 
 **Verificar:**
 - [ ] Imports funcionam
 - [ ] Testes passam
-- [ Health check retorna 200 (não 401)
+- [ ] Health check retorna 200 (não 401)
 - [ ] Requirements.txt está completo
 
 ### 7. Commitar

--- a/.opencode/skills/verificar-deploy/SKILL.md
+++ b/.opencode/skills/verificar-deploy/SKILL.md
@@ -5,16 +5,20 @@ description: Verifica se o código está pronto para deploy antes de subir.
 
 # Verificar Deploy — Movecity
 
-Esta skill verifica se o código está pronto para deploy, prevenindo erros como health check retornando 401.
+Esta skill verifica se o código está pronto para deploy, prevenindo erros como dependências faltando e health check retornando 401.
 
-## Checklist Pré-Deploy
+## Comando Rápido
+
+```bash
+./scripts/verificar-deploy.sh
+```
+
+## Checklist Pré-Deploy (manual)
 
 ### 1. Health Check
 
 ```bash
-# Testar localmente
 curl http://localhost:8000/health
-
 # Esperado: {"status":"ok","service":"gateway","environment":"..."}
 # NÃO deve retornar 401
 ```
@@ -22,11 +26,8 @@ curl http://localhost:8000/health
 ### 2. Rotas Públicas
 
 ```bash
-# Gateway
 curl http://localhost:8000/gateway/hello
 curl http://localhost:8000/gateway/health
-
-# Auth
 curl http://localhost:8000/auth/login
 curl http://localhost:8000/auth/registrar
 curl http://localhost:8000/auth/refresh
@@ -42,37 +43,22 @@ curl http://localhost:8000/gateway/hello
 ### 4. Requirements
 
 ```bash
-# Verificar se todas as dependências estão no requirements.txt
 pip install -r requirements.txt --dry-run
 ```
 
 ### 5. Testes
 
 ```bash
-# Backend
 cd src/backend && pytest -v
-
-# Frontend
 cd src/frontend && npm test
 ```
 
 ### 6. Imports
 
 ```bash
-# Verificar se imports funcionam
 cd src/backend
 python -c "from gateway.main import app; print('Gateway OK')"
 python -c "from auth.main import app; print('Auth OK')"
-```
-
-## Comandos Rápidos
-
-```bash
-# Verificar tudo de uma vez
-cd src/backend
-python -c "from gateway.main import app; print('Gateway OK')" && \
-pytest -v && \
-curl http://localhost:8000/health
 ```
 
 ## Erros Comuns
@@ -85,6 +71,7 @@ curl http://localhost:8000/health
 
 ## Referências
 
+- Script: `scripts/verificar-deploy.sh`
 - Middleware: `src/backend/gateway/middleware.py`
 - Health check: `src/backend/gateway/main.py`
 - Requirements: `src/backend/gateway/requirements.txt`

--- a/.opencode/skills/verificar-deploy/SKILL.md
+++ b/.opencode/skills/verificar-deploy/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: verificar-deploy
+description: Verifica se o código está pronto para deploy antes de subir.
+---
+
+# Verificar Deploy — Movecity
+
+Esta skill verifica se o código está pronto para deploy, prevenindo erros como health check retornando 401.
+
+## Checklist Pré-Deploy
+
+### 1. Health Check
+
+```bash
+# Testar localmente
+curl http://localhost:8000/health
+
+# Esperado: {"status":"ok","service":"gateway","environment":"..."}
+# NÃO deve retornar 401
+```
+
+### 2. Rotas Públicas
+
+```bash
+# Gateway
+curl http://localhost:8000/gateway/hello
+curl http://localhost:8000/gateway/health
+
+# Auth
+curl http://localhost:8000/auth/login
+curl http://localhost:8000/auth/registrar
+curl http://localhost:8000/auth/refresh
+```
+
+### 3. Rotas Protegidas (devem retornar 401 sem token)
+
+```bash
+curl http://localhost:8000/gateway/hello
+# Esperado: {"detail":"Não autenticado"}
+```
+
+### 4. Requirements
+
+```bash
+# Verificar se todas as dependências estão no requirements.txt
+pip install -r requirements.txt --dry-run
+```
+
+### 5. Testes
+
+```bash
+# Backend
+cd src/backend && pytest -v
+
+# Frontend
+cd src/frontend && npm test
+```
+
+### 6. Imports
+
+```bash
+# Verificar se imports funcionam
+cd src/backend
+python -c "from gateway.main import app; print('Gateway OK')"
+python -c "from auth.main import app; print('Auth OK')"
+```
+
+## Comandos Rápidos
+
+```bash
+# Verificar tudo de uma vez
+cd src/backend
+python -c "from gateway.main import app; print('Gateway OK')" && \
+pytest -v && \
+curl http://localhost:8000/health
+```
+
+## Erros Comuns
+
+| Erro | Causa | Solução |
+|------|-------|---------|
+| Health check retorna 401 | Rota não está na lista de rotas públicas | Adicionar `/health` em `ROTAS_PUBLICAS` |
+| `ModuleNotFoundError` | Dependência faltando no requirements.txt | Adicionar dependência |
+| Import error | Arquivo não existe ou path incorreto | Verificar path do import |
+
+## Referências
+
+- Middleware: `src/backend/gateway/middleware.py`
+- Health check: `src/backend/gateway/main.py`
+- Requirements: `src/backend/gateway/requirements.txt`

--- a/docs/checklist-pre-commit.md
+++ b/docs/checklist-pre-commit.md
@@ -2,34 +2,39 @@
 
 Antes de fazer `git commit`, verificar:
 
-## Código
+## Comando Rápido
 
+```bash
+./scripts/verificar-deploy.sh
+```
+
+## Verificações Manuais
+
+### Código
 - [ ] Imports funcionam (`python -c "from X import Y"`)
 - [ ] Requirements.txt está completo
 - [ ] Testes passam localmente
 - [ ] Lint não tem erros
 
-## Deploy
-
+### Deploy
 - [ ] Health check funciona (`curl /health`)
 - [ ] Rotas públicas funcionam
 - [ ] Rotas protegidas retornam 401 sem token
 
-## Migrations
-
+### Migrations
 - [ ] Migrations funcionam (se aplicável)
 - [ ] Alembic upgrade head roda sem erro
 
-## Como Usar
+## Como Usar o Script
 
 ```bash
-# Verificar imports
-cd src/backend
-python -c "from gateway.main import app; print('Gateway OK')"
+# Verificar tudo de uma vez
+./scripts/verificar-deploy.sh
 
-# Rodar testes
-pytest -v
-
-# Verificar health check (com backend rodando)
-curl http://localhost:8000/health
+# O script verifica:
+# 1. Dependências do requirements.txt
+# 2. Imports do Gateway e Auth
+# 3. Health check (deve retornar 200)
+# 4. Rotas públicas
+# 5. Rota protegida (deve retornar 401)
 ```

--- a/docs/checklist-pre-commit.md
+++ b/docs/checklist-pre-commit.md
@@ -1,0 +1,35 @@
+# Checklist Pré-Commit
+
+Antes de fazer `git commit`, verificar:
+
+## Código
+
+- [ ] Imports funcionam (`python -c "from X import Y"`)
+- [ ] Requirements.txt está completo
+- [ ] Testes passam localmente
+- [ ] Lint não tem erros
+
+## Deploy
+
+- [ ] Health check funciona (`curl /health`)
+- [ ] Rotas públicas funcionam
+- [ ] Rotas protegidas retornam 401 sem token
+
+## Migrations
+
+- [ ] Migrations funcionam (se aplicável)
+- [ ] Alembic upgrade head roda sem erro
+
+## Como Usar
+
+```bash
+# Verificar imports
+cd src/backend
+python -c "from gateway.main import app; print('Gateway OK')"
+
+# Rodar testes
+pytest -v
+
+# Verificar health check (com backend rodando)
+curl http://localhost:8000/health
+```

--- a/scripts/verificar-deploy.sh
+++ b/scripts/verificar-deploy.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+cd "$ROOT_DIR"
+
+echo "=========================================="
+echo "  Movecity — Verificação Pré-Deploy"
+echo "=========================================="
+
+ERROS=0
+
+echo ""
+echo "[1/4] Verificando dependências do Gateway..."
+if pip install -r src/backend/gateway/requirements.txt --dry-run 2>/dev/null; then
+    echo "  ✅ Dependências OK"
+else
+    echo "  ❌ Dependências faltando no requirements.txt"
+    ERROS=$((ERROS + 1))
+fi
+
+echo ""
+echo "[2/4] Verificando imports..."
+if python -c "from gateway.main import app; print('  ✅ Gateway OK')" 2>/dev/null; then
+    true
+else
+    echo "  ❌ Gateway: import falhou"
+    ERROS=$((ERROS + 1))
+fi
+
+if python -c "from auth.main import app; print('  ✅ Auth OK')" 2>/dev/null; then
+    true
+else
+    echo "  ❌ Auth: import falhou"
+    ERROS=$((ERROS + 1))
+fi
+
+echo ""
+echo "[3/4] Verificando health check..."
+cd src/backend
+uvicorn gateway.main:app --host 0.0.0.0 --port 8000 &
+UVICORN_PID=$!
+sleep 3
+
+if curl -sf http://localhost:8000/health > /dev/null 2>&1; then
+    echo "  ✅ Health check OK"
+else
+    echo "  ❌ Health check falhou (esperado 200)"
+    ERROS=$((ERROS + 1))
+fi
+
+kill $UVICORN_PID 2>/dev/null || true
+wait $UVICORN_PID 2>/dev/null || true
+cd "$ROOT_DIR"
+
+echo ""
+echo "[4/4] Verificando rotas públicas..."
+cd src/backend
+uvicorn gateway.main:app --host 0.0.0.0 --port 8000 &
+UVICORN_PID=$!
+sleep 3
+
+for ROTA in "/health" "/gateway/hello" "/gateway/health"; do
+    if curl -sf "http://localhost:8000${ROTA}" > /dev/null 2>&1; then
+        echo "  ✅ ${ROTA}"
+    else
+        echo "  ❌ ${ROTA} falhou"
+        ERROS=$((ERROS + 1))
+    fi
+done
+
+echo ""
+echo "Verificando rota protegida (deve retornar 401)..."
+HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:8000/gateway/hello)
+if [ "$HTTP_CODE" = "401" ]; then
+    echo "  ✅ /gateway/hello retorna 401 (correto)"
+else
+    echo "  ❌ /gateway/hello retornou ${HTTP_CODE} (esperado 401)"
+    ERROS=$((ERROS + 1))
+fi
+
+kill $UVICORN_PID 2>/dev/null || true
+wait $UVICORN_PID 2>/dev/null || true
+cd "$ROOT_DIR"
+
+echo ""
+echo "=========================================="
+if [ $ERROS -eq 0 ]; then
+    echo "  ✅ Tudo OK! Pronto para deploy."
+    echo "=========================================="
+    exit 0
+else
+    echo "  ❌ ${ERROS} erro(s) encontrado(s)."
+    echo "  Corrija antes de fazer deploy."
+    echo "=========================================="
+    exit 1
+fi

--- a/src/backend/gateway/middleware.py
+++ b/src/backend/gateway/middleware.py
@@ -9,6 +9,7 @@ class AutenticacaoMiddleware(BaseHTTPMiddleware):
     ROTAS_PUBLICAS = [
         "/gateway/hello",
         "/gateway/health",
+        "/health",
         "/auth/login",
         "/auth/registrar",
         "/auth/refresh",


### PR DESCRIPTION
## Correções

- Adicionar /health nas rotas públicas do middleware (resolve deploy 401)
- Remover modelo incorreto do agente dev-environment
- Criar skill verificar-deploy
- Atualizar skill desenvolver-us-backend
- Criar checklist pré-commit

## Problema

O health check do Fly.io chamava , mas o middleware só permitia . Resultado: deploy falhava com 401 após 10 tentativas.

## Solução

Adicionar  na lista de rotas públicas do middleware.