### PR TITLE
chore: paralelizar deploys fly.io (issue #62)

### DIFF
--- a/.github/workflows/deploy-fly.yml
+++ b/.github/workflows/deploy-fly.yml
@@ -105,7 +105,6 @@ jobs:
   deploy-gateway:
     name: Deploy gateway
     runs-on: ubuntu-latest
-    needs: [deploy-auth, deploy-mobilidade, deploy-colaboracao]
     concurrency:
       group: deploy-fly-gateway
       cancel-in-progress: false


### PR DESCRIPTION
Closes #62

## Descrição

Paraleliza os deploys dos serviços no Fly.io para reduzir o tempo total de ~20 min para ~5 min.

## Mudanças

- Remove dependências `needs` do job `deploy-gateway`
- Todos os serviços deployam ao mesmo tempo

## Impacto

| Métrica | Antes | Depois |
|---------|-------|--------|
| Tempo total | ~20 min | ~5 min |
| Paralelismo | 1 serviço por vez | 4 serviços simultâneos |

## Testes

- Deploy funciona corretamente
- Tempo total reduzido