### PR TITLE
fix: adicionar /doc e /redoc nas rotas publicas do gateway

### DIFF
--- a/src/backend/gateway/middleware.py
+++ b/src/backend/gateway/middleware.py
@@ -13,6 +13,9 @@ class AutenticacaoMiddleware(BaseHTTPMiddleware):
         "/auth/login",
         "/auth/registrar",
         "/auth/refresh",
+        "/doc",
+        "/redoc",
+        "/openapi.json",
     ]
 
     async def dispatch(self, request: Request, call_next):


### PR DESCRIPTION
Adiciona `/doc`, `/redoc` e `/openapi.json` nas rotas públicas do middleware para permitir acesso à documentação Swagger UI sem autenticação.

## Mudanças

- Adiciona `/doc` (Swagger UI) nas rotas públicas
- Adiciona `/redoc` (ReDoc) nas rotas públicas
- Adiciona `/openapi.json` (OpenAPI schema) nas rotas públicas

## Motivo

O endpoint `/doc` estava retornando 401 "Não autenticado", impedindo o acesso à documentação da API.

## Testes

- [ ] Acessar `https://movecity-gateway.fly.dev/doc` sem autenticação
- [ ] Acessar `https://movecity-gateway.fly.dev/redoc` sem autenticação
- [ ] Acessar `https://movecity-gateway.fly.dev/openapi.json` sem autenticação