### PR TITLE
fix: gateway não consegue falar com os serviços de domínio (IPv4/IPv6 no Fly.io)

### DIFF
--- a/src/backend/auth/Dockerfile
+++ b/src/backend/auth/Dockerfile
@@ -13,4 +13,4 @@ COPY src/backend/auth ./auth
 
 EXPOSE 8000
 
-CMD ["uvicorn", "auth.main:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["uvicorn", "auth.main:app", "--host", "::", "--port", "8000"]

--- a/src/backend/colaboracao/Dockerfile
+++ b/src/backend/colaboracao/Dockerfile
@@ -13,4 +13,4 @@ COPY src/backend/colaboracao ./colaboracao
 
 EXPOSE 8000
 
-CMD ["uvicorn", "colaboracao.main:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["uvicorn", "colaboracao.main:app", "--host", "::", "--port", "8000"]

--- a/src/backend/gateway/Dockerfile
+++ b/src/backend/gateway/Dockerfile
@@ -13,4 +13,4 @@ COPY src/backend/gateway ./gateway
 
 EXPOSE 8000
 
-CMD ["uvicorn", "gateway.main:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["uvicorn", "gateway.main:app", "--host", "::", "--port", "8000"]

--- a/src/backend/gateway/config.py
+++ b/src/backend/gateway/config.py
@@ -4,9 +4,9 @@ from pydantic_settings import BaseSettings
 class GatewaySettings(BaseSettings):
     """Configuração dos serviços backend para proxy."""
 
-    AUTH_SERVICE_URL: str = "http://auth-service:8000"
-    MOBILIDADE_SERVICE_URL: str = "http://mobilidade-service:8000"
-    COLABORACAO_SERVICE_URL: str = "http://colaboracao-service:8000"
+    AUTH_SERVICE_URL: str = "http://movecity-auth.internal:8000"
+    MOBILIDADE_SERVICE_URL: str = "http://movecity-mobilidade.internal:8000"
+    COLABORACAO_SERVICE_URL: str = "http://movecity-colaboracao.internal:8000"
 
     class Config:
         env_prefix = "GATEWAY_"

--- a/src/backend/gateway/proxy.py
+++ b/src/backend/gateway/proxy.py
@@ -13,13 +13,26 @@ async def proxy_request(service_url: str, path: str, request: Request) -> Respon
     headers = dict(request.headers)
     headers.pop("host", None)
 
-    async with httpx.AsyncClient() as client:
-        response = await client.request(
-            method=request.method,
-            url=f"{service_url}{path}",
-            headers=headers,
-            content=body if body else None,
-            timeout=30.0,
+    try:
+        async with httpx.AsyncClient() as client:
+            response = await client.request(
+                method=request.method,
+                url=f"{service_url}{path}",
+                headers=headers,
+                content=body if body else None,
+                timeout=30.0,
+            )
+    except httpx.TimeoutException:
+        return Response(
+            content='{"detail": "Serviço demorou demais para responder."}',
+            status_code=504,
+            media_type="application/json",
+        )
+    except httpx.ConnectError:
+        return Response(
+            content='{"detail": "Serviço indisponível no momento."}',
+            status_code=502,
+            media_type="application/json",
         )
 
     excluded_headers = {

--- a/src/backend/mobilidade/Dockerfile
+++ b/src/backend/mobilidade/Dockerfile
@@ -13,4 +13,4 @@ COPY src/backend/mobilidade ./mobilidade
 
 EXPOSE 8000
 
-CMD ["uvicorn", "mobilidade.main:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["uvicorn", "mobilidade.main:app", "--host", "::", "--port", "8000"]


### PR DESCRIPTION
## Descrição

O Gateway (US #31 — proxy) estava devolvendo `500 Internal Server Error` em texto puro para toda chamada de `/api/auth/*`, `/api/mobilidade/*` e `/api/colaboracao/*` em homolog.

**Causa raiz:** os 4 serviços (`gateway`, `auth`, `mobilidade`, `colaboracao`) sobem com `uvicorn --host 0.0.0.0`, escutando só em IPv4. A rede privada do Fly.io (`*.internal`, usada para comunicação serviço-a-serviço) é **IPv6-only**. Confirmado via SSH direto na máquina do `auth`: a tabela `tcp6` não tinha nada escutando na porta 8000, só `tcp4`. Resultado: o Gateway nunca conseguia abrir conexão com os serviços de domínio (`ConnectionRefusedError`/`ConnectError`), e a exceção não tratada em `proxy.py` virava um 500 cru.

## O que foi corrigido

- **4x `Dockerfile`** (gateway/auth/mobilidade/colaboracao): `--host 0.0.0.0` → `--host ::` (dual-stack, aceita IPv4 e IPv6).
- **`gateway/proxy.py`**: captura `httpx.ConnectError`/`httpx.TimeoutException` e devolve 502/504 em JSON em vez de deixar a exceção estourar como 500 em texto puro.
- **`gateway/config.py`**: hostnames default corrigidos de `http://auth-service:8000` (não existe) para `http://movecity-auth.internal:8000` (real), como rede de segurança caso a secret não esteja setada.

## Já aplicado manualmente em homolog (fora deste PR, com autorização)

Pra destravar o time enquanto o PR não é revisado:
- Apliquei direto no Postgres (Neon) de homolog as duas migrations que nunca tinham rodado lá (`alembic_version` estava travado em `66561f25d09c`, e as tabelas `usuarios`/`sessoes` nem existiam).
- Setei as secrets `GATEWAY_AUTH_SERVICE_URL`, `GATEWAY_MOBILIDADE_SERVICE_URL`, `GATEWAY_COLABORACAO_SERVICE_URL` no `movecity-gateway` (não existiam).

Esse PR resolve a causa raiz de fato (bind IPv6) pra que o próximo deploy funcione de ponta a ponta.

## Débito técnico identificado (fora de escopo deste PR)

- Migrations do Alembic nunca rodam automaticamente no deploy (`deploy-fly.yml` só faz `flyctl deploy`, e o diretório `alembic/` nem é copiado pras imagens Docker). Vale abrir issue separada.
- `docs/deploy-plan.md` está desatualizado (portas internas erradas, endpoints de smoke test sem o prefixo `/api`).
- Só existe uma branch no Neon (`main`) — não há separação homolog/produção no banco (issue #42, ainda aberta).

## Como testar

1. Aprovar e mergear este PR em `homolog` (dispara deploy automático dos 4 serviços via GitHub Actions).
2. `curl -X POST https://movecity-gateway.fly.dev/api/auth/registrar -d '{...}'` deve retornar 200/409, não mais 500.
3. `curl -X POST https://movecity-gateway.fly.dev/api/auth/login -d '{...}'` deve retornar 200/401, não mais 500.

## Issue vinculada

Relacionado a #31 (Gateway como Proxy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Jff434FipizyJUdsmiYtf