### PR TITLE
feat: painel de status dos serviços na home

### DIFF
--- a/src/backend/gateway/middleware.py
+++ b/src/backend/gateway/middleware.py
@@ -12,6 +12,7 @@ class AutenticacaoMiddleware(BaseHTTPMiddleware):
         "/health",
         "/",
         "/api/hello",
+        "/api/status",
         "/api/auth/login",
         "/api/auth/registrar",
         "/api/auth/refresh",

--- a/src/backend/gateway/routes.py
+++ b/src/backend/gateway/routes.py
@@ -1,3 +1,6 @@
+import asyncio
+
+import httpx
 from fastapi import APIRouter, Request, Response
 
 from gateway.config import get_gateway_settings
@@ -11,6 +14,43 @@ settings = get_gateway_settings()
 @router.get("/hello")
 def hello():
     return {"service": "gateway", "status": "ok"}
+
+
+@router.get("/status")
+async def status():
+    """Status agregado do gateway e dos serviços de domínio.
+
+    Usado pela home do frontend para exibir quais serviços estão
+    no ar. Uma chamada aqui já "acorda" serviços do Fly.io que
+    estejam ociosos (auto_stop_machines), pois qualquer request
+    HTTP ao serviço dispara o auto_start.
+    """
+    servicos = {
+        "auth": settings.AUTH_SERVICE_URL,
+        "mobilidade": settings.MOBILIDADE_SERVICE_URL,
+        "colaboracao": settings.COLABORACAO_SERVICE_URL,
+    }
+
+    async def verificar(nome: str, url: str) -> dict:
+        try:
+            async with httpx.AsyncClient(timeout=10.0) as client:
+                resposta = await client.get(f"{url}/health")
+            return {
+                "service": nome,
+                "status": "ok" if resposta.status_code == 200 else "error",
+            }
+        except httpx.HTTPError:
+            return {"service": nome, "status": "error"}
+
+    resultados = await asyncio.gather(
+        *(verificar(nome, url) for nome, url in servicos.items())
+    )
+
+    return {
+        "service": "gateway",
+        "status": "ok",
+        "servicos": [{"service": "gateway", "status": "ok"}, *resultados],
+    }
 
 
 # ============================================

--- a/src/backend/gateway/tests/test_status.py
+++ b/src/backend/gateway/tests/test_status.py
@@ -1,0 +1,45 @@
+from unittest.mock import AsyncMock, patch
+
+from fastapi.testclient import TestClient
+
+from gateway.main import app
+
+client = TestClient(app)
+
+
+def _resposta_mock(status_code: int):
+    resposta = AsyncMock()
+    resposta.status_code = status_code
+    return resposta
+
+
+def test_status_agrega_servicos_ok():
+    with patch("httpx.AsyncClient.get", AsyncMock(return_value=_resposta_mock(200))):
+        response = client.get("/api/status")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["service"] == "gateway"
+    nomes = {s["service"] for s in data["servicos"]}
+    assert nomes == {"gateway", "auth", "mobilidade", "colaboracao"}
+    assert all(s["status"] == "ok" for s in data["servicos"])
+
+
+def test_status_marca_servico_indisponivel_como_error():
+    import httpx
+
+    with patch(
+        "httpx.AsyncClient.get",
+        AsyncMock(side_effect=httpx.ConnectError("falhou")),
+    ):
+        response = client.get("/api/status")
+
+    assert response.status_code == 200
+    data = response.json()
+    servicos_com_erro = [s for s in data["servicos"] if s["service"] != "gateway"]
+    assert all(s["status"] == "error" for s in servicos_com_erro)
+
+
+def test_status_e_rota_publica_sem_autenticacao():
+    response = client.get("/api/status")
+    assert response.status_code != 401

--- a/src/frontend/app/__tests__/page.test.tsx
+++ b/src/frontend/app/__tests__/page.test.tsx
@@ -5,7 +5,16 @@ describe("Home", () => {
   beforeEach(() => {
     global.fetch = jest.fn().mockResolvedValue({
       ok: true,
-      json: async () => ({ service: "gateway", status: "ok" }),
+      json: async () => ({
+        service: "gateway",
+        status: "ok",
+        servicos: [
+          { service: "gateway", status: "ok" },
+          { service: "auth", status: "ok" },
+          { service: "mobilidade", status: "ok" },
+          { service: "colaboracao", status: "ok" },
+        ],
+      }),
     }) as jest.Mock;
   });
 

--- a/src/frontend/lib/api.ts
+++ b/src/frontend/lib/api.ts
@@ -5,28 +5,34 @@ export interface ServiceStatus {
   status: string;
 }
 
-export async function fetchServiceStatus(
-  service: string
-): Promise<ServiceStatus> {
-  const response = await fetch(`${API_URL}/${service}/hello`);
-  if (!response.ok) {
-    throw new Error(`Erro ao buscar status do serviço ${service}`);
-  }
-  return response.json();
+interface StatusAgregadoResponse {
+  service: string;
+  status: string;
+  servicos: ServiceStatus[];
 }
 
-export async function fetchAllServicesStatus(): Promise<
-  ServiceStatus[]
-> {
-  const services = ["gateway", "auth", "mobilidade", "colaboracao"];
-  const results = await Promise.allSettled(
-    services.map((service) => fetchServiceStatus(service))
-  );
-
-  return results.map((result, index) => ({
-    service: services[index],
-    status: result.status === "fulfilled" ? result.value.status : "error",
-  }));
+/**
+ * Busca o status do gateway e dos serviços de domínio (auth,
+ * mobilidade, colaboracao) em uma única chamada ao Gateway
+ * (/api/status), o ponto único de entrada. Cada chamada aqui já
+ * "acorda" serviços do Fly.io que estejam ociosos, já que qualquer
+ * request HTTP dispara o auto_start_machines.
+ */
+export async function fetchAllServicesStatus(): Promise<ServiceStatus[]> {
+  try {
+    const response = await fetch(`${API_URL}/api/status`, {
+      cache: "no-store",
+    });
+    if (!response.ok) {
+      throw new Error("Erro ao buscar status dos serviços");
+    }
+    const data: StatusAgregadoResponse = await response.json();
+    return data.servicos;
+  } catch {
+    return ["gateway", "auth", "mobilidade", "colaboracao"].map(
+      (service) => ({ service, status: "error" })
+    );
+  }
 }
 
 export interface RegistroPayload {


### PR DESCRIPTION
## Descrição

Home do frontend passa a exibir o status de todos os 4 serviços (gateway, auth, mobilidade, colaboracao) toda vez que a página é carregada/recarregada, e uma requisição a um serviço ocioso no Fly.io (`auto_stop_machines`) já dispara o `auto_start` dele.

## O que mudou

- **`gateway/routes.py`**: novo `GET /api/status`, rota pública — o Gateway chama `/health` dos 3 serviços de domínio em paralelo e devolve um agregado.
- **`gateway/middleware.py`**: `/api/status` adicionada às rotas públicas.
- **`frontend/lib/api.ts`**: `fetchAllServicesStatus` agora bate só no Gateway (ponto único de entrada, US #31) em vez de bater direto em cada serviço — o que também corrige os paths antigos (`/auth/hello`, `/mobilidade/hello`...) que não existem mais desde o proxy do gateway.
- Testes: 3 novos testes de `/api/status` (agregação ok, serviço indisponível vira `error`, rota é pública) + teste da home atualizado pro novo formato de resposta.

## Dependência

Esse PR só funciona de ponta a ponta depois que **#76** (fix do bind IPv4/IPv6) for mergeado — sem ele, `/api/status` sobe normalmente mas mostra auth/mobilidade/colaboracao como `error` (o gateway não consegue alcançá-los). Recomendo mergear #76 primeiro.

## Já aplicado manualmente em homolog (fora deste PR)

Setei a secret `CORS_ORIGINS` no `movecity-gateway` incluindo `https://movecity-frontend.vercel.app` (só tinha `localhost:3000`) — sem isso o navegador bloqueava qualquer chamada do site publicado pro Gateway, inclusive login/cadastro.

## Como testar

1. Mergear #76 primeiro.
2. `curl https://movecity-gateway.fly.dev/api/status` deve retornar os 4 serviços com `status: ok`.
3. Abrir https://movecity-frontend.vercel.app e ver o painel na home.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Jff434FipizyJUdsmiYtf