### PR TITLE
chore: rodar migrations do Alembic automaticamente no deploy

### DIFF
--- a/.github/workflows/deploy-fly.yml
+++ b/.github/workflows/deploy-fly.yml
@@ -9,8 +9,32 @@ on:
   workflow_dispatch:
 
 jobs:
+  migrate:
+    name: Rodar migrations (Alembic)
+    runs-on: ubuntu-latest
+    concurrency:
+      group: deploy-fly-migrate
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+      - name: Instalar dependências
+        run: |
+          cd src/backend
+          pip install -r requirements.txt
+      - name: alembic upgrade head
+        run: |
+          cd src/backend
+          alembic upgrade head
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+
   deploy-auth:
     name: Deploy auth
+    needs: migrate
     runs-on: ubuntu-latest
     concurrency:
       group: deploy-fly-auth
@@ -42,6 +66,7 @@ jobs:
 
   deploy-mobilidade:
     name: Deploy mobilidade
+    needs: migrate
     runs-on: ubuntu-latest
     concurrency:
       group: deploy-fly-mobilidade
@@ -73,6 +98,7 @@ jobs:
 
   deploy-colaboracao:
     name: Deploy colaboracao
+    needs: migrate
     runs-on: ubuntu-latest
     concurrency:
       group: deploy-fly-colaboracao


### PR DESCRIPTION
## Descrição

O `deploy-fly.yml` fazia só `flyctl deploy` — nunca aplicava as migrations do Alembic no banco real. Resultado: o `alembic_version` de homolog ficou travado 2 migrations atrás do código por dias (as tabelas `usuarios`/`sessoes` nem existiam), e todo `/api/auth/registrar`/`login` dava 500.

## O que mudou

- Novo job `migrate` no `deploy-fly.yml`: roda `alembic upgrade head` contra o Postgres real, usando a nova secret `DATABASE_URL` do GitHub Actions.
- `deploy-auth`, `deploy-mobilidade`, `deploy-colaboracao` agora dependem (`needs: migrate`) desse job — só sobem depois que o schema estiver em dia.
- `deploy-gateway` fica independente (não acessa banco).

## Por que não dentro do container

O `alembic/` nem é copiado pras imagens Docker dos serviços (e `alembic` não está no `requirements.txt` deles) — rodar no runner do GitHub Actions, antes do deploy, é mais simples que mudar os 3 Dockerfiles + imagem pra carregar o alembic em produção.

## Nova secret

Adicionei `DATABASE_URL` (connection string do Neon) como secret do repositório — usada só neste job, nunca logada.

## Como testar

Mergear e observar a run do `Deploy Backend (Fly.io)`: o job `migrate` deve rodar antes dos 3 deploys e terminar com `No new migrations` (o banco de homolog já está com o schema em dia, corrigido manualmente antes desta PR).

## Relacionado

Endereça a causa raiz do bug descrito no PR #76.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Jff434FipizyJUdsmiYtf