### PR TITLE
chore: homolog passa a deployar --prod pro domínio público da Vercel

### DIFF
--- a/.github/workflows/deploy-vercel.yml
+++ b/.github/workflows/deploy-vercel.yml
@@ -1,8 +1,15 @@
 name: Deploy Frontend (Vercel)
 
+# Nesta fase do projeto, homolog É o ambiente "de produção" visível
+# publicamente (movecity-frontend.vercel.app) — é onde tudo que está
+# sendo desenvolvido roda de verdade. main ainda não tem deploy próprio;
+# quando o projeto tiver um ambiente de produção separado de verdade,
+# reintroduzir um job deploy-producao (if: github.ref == 'refs/heads/main')
+# apontando pra outro domínio/projeto Vercel.
+
 on:
   push:
-    branches: [homolog, main]
+    branches: [homolog]
     paths:
       - "src/frontend/**"
       - ".github/workflows/deploy-vercel.yml"
@@ -10,43 +17,11 @@ on:
 
 jobs:
   deploy-homolog:
-    name: Deploy Homolog (Preview)
+    name: Deploy Homolog (Produção pública)
     if: github.ref == 'refs/heads/homolog'
     runs-on: ubuntu-latest
     concurrency:
       group: deploy-vercel-homolog
-      cancel-in-progress: false
-    env:
-      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Instalar Vercel CLI
-        run: npm install --global vercel@latest
-
-      - name: Puxar configuração do ambiente (Preview)
-        run: vercel pull --yes --environment=preview --token=$VERCEL_TOKEN
-
-      - name: Build do projeto
-        run: vercel build --token=$VERCEL_TOKEN
-
-      - name: Deploy (Preview)
-        id: deploy
-        run: |
-          url=$(vercel deploy --prebuilt --token=$VERCEL_TOKEN)
-          echo "url=$url" >> "$GITHUB_OUTPUT"
-
-      - name: Apontar alias fixo de homolog
-        run: vercel alias set "${{ steps.deploy.outputs.url }}" movecity-frontend-homolog.vercel.app --token=$VERCEL_TOKEN
-
-  deploy-producao:
-    name: Deploy Produção
-    if: github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
-    concurrency:
-      group: deploy-vercel-producao
       cancel-in-progress: false
     env:
       VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}


### PR DESCRIPTION
## Descrição

Nesta fase do projeto, `homolog` é o ambiente visível publicamente — é onde tudo que o time desenvolve roda de verdade. `main` quase não recebe merge ainda. Fazia sentido isso ficar invertido: `main` deployava pro domínio público (`movecity-frontend.vercel.app`) enquanto `homolog` ficava só num link de preview atrás do SSO da Vercel (`movecity-frontend-homolog.vercel.app`), que ninguém conseguia abrir sem estar logado na conta Vercel do projeto.

## O que mudou

- Push em `homolog` agora builda/deploya `--prod` direto pro domínio público (mesmo fluxo que `main` usava).
- Removido o job `deploy-producao` (branch `main`) por enquanto — comentário no arquivo explica como reintroduzir quando o projeto tiver um ambiente de produção separado de verdade.
- Isso elimina o link de preview preso no SSO.

## Já aplicado fora deste PR

Corrigi a variável `NEXT_PUBLIC_API_URL` nos ambientes Preview e Production da Vercel (apontava pra `localhost:8000` em Preview, e possivelmente errada em Production) — sem isso nenhum deploy conseguiria falar com o Gateway.

## Como testar

Mergear, aguardar o `Deploy Frontend (Vercel)` rodar, e abrir `https://movecity-frontend.vercel.app` — deve ter home (painel de status), `/login` e `/cadastro` funcionando.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Jff434FipizyJUdsmiYtf