### PR TITLE
fix: front-end batia em /auth/registro e /auth/login (paths errados no Gateway)

### DIFF
--- a/src/frontend/lib/__tests__/api.test.ts
+++ b/src/frontend/lib/__tests__/api.test.ts
@@ -1,0 +1,49 @@
+import { registrarUsuario, loginUsuario } from "../api";
+
+/**
+ * Regressão: o front-end já bateu em /auth/registro e /auth/login
+ * (sem o prefixo /api, e "registro" em vez de "registrar") — paths
+ * que não existem no Gateway (só /api/auth/registrar e /api/auth/login
+ * são roteados/públicos). Isso travava CORS + 401 em produção.
+ */
+describe("api.ts — paths do Gateway", () => {
+  beforeEach(() => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        id: "1",
+        nome: "Teste",
+        email: "teste@example.com",
+        mensagem: "ok",
+        access_token: "a",
+        refresh_token: "b",
+        token_type: "bearer",
+      }),
+    }) as jest.Mock;
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("registrarUsuario chama /api/auth/registrar", async () => {
+    await registrarUsuario({
+      nome: "Teste",
+      email: "teste@example.com",
+      senha: "senha123",
+      termosAceitos: true,
+    });
+
+    const [url] = (global.fetch as jest.Mock).mock.calls[0];
+    expect(url).toMatch(/\/api\/auth\/registrar$/);
+  });
+
+  it("loginUsuario chama /api/auth/login com credentials include", async () => {
+    await loginUsuario({ email: "teste@example.com", senha: "senha123" });
+
+    const [url, options] = (global.fetch as jest.Mock).mock.calls[0];
+    expect(url).toMatch(/\/api\/auth\/login$/);
+    expect(options.credentials).toBe("include");
+  });
+});

--- a/src/frontend/lib/api.ts
+++ b/src/frontend/lib/api.ts
@@ -54,7 +54,7 @@ export class RegistroError extends Error {}
 export async function registrarUsuario(
   dados: RegistroPayload
 ): Promise<RegistroResponse> {
-  const response = await fetch(`${API_URL}/auth/registro`, {
+  const response = await fetch(`${API_URL}/api/auth/registrar`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({
@@ -91,7 +91,8 @@ export class LoginError extends Error {}
 export async function loginUsuario(
   dados: LoginPayload
 ): Promise<LoginResponse> {
-  const response = await fetch(`${API_URL}/auth/login`, {
+  const response = await fetch(`${API_URL}/api/auth/login`, {
+    credentials: "include",
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({


### PR DESCRIPTION
## Descrição

Erro reportado no navegador ao tentar cadastrar:

```
Cross-Origin Request Blocked: ... https://movecity-gateway.fly.dev/auth/registro
Reason: CORS header 'Access-Control-Allow-Origin' missing. Status: 401.
```

Causa: `lib/api.ts` batia em `/auth/registro` e `/auth/login` — nenhum dos dois existe no Gateway. As rotas reais são `/api/auth/registrar` e `/api/auth/login` (prefixo `/api`, e "registrar" não "registro"). Como o path não existe / não está na whitelist de rotas públicas do middleware, a resposta vinha sem header de CORS, e o navegador bloqueava antes mesmo de mostrar o 401 real.

## O que mudou

- `registrarUsuario`: `/auth/registro` → `/api/auth/registrar`.
- `loginUsuario`: `/auth/login` → `/api/auth/login`, + `credentials: "include"` (sem isso o navegador descarta os cookies httpOnly que o Gateway seta no login, mesmo com CORS `allow_credentials` habilitado no backend).
- 2 testes novos de regressão travando os paths corretos.

## Como testar

Depois de mergear (e o #80 já estar no ar), abrir `https://movecity-frontend.vercel.app/cadastro` e cadastrar de verdade — sem erro de CORS no console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Jff434FipizyJUdsmiYtf