### PR TITLE
fix: proxy do gateway não decodifica resposta comprimida (zstd) do serviço

### DIFF
--- a/src/backend/gateway/proxy.py
+++ b/src/backend/gateway/proxy.py
@@ -12,6 +12,12 @@ async def proxy_request(service_url: str, path: str, request: Request) -> Respon
 
     headers = dict(request.headers)
     headers.pop("host", None)
+    # Não repassar o Accept-Encoding do cliente: o navegador anuncia
+    # codecs (ex.: zstd, br) que o httpx do Gateway não sabe
+    # descomprimir sem pacotes extras. Deixar o httpx negociar sua
+    # própria compressão com o serviço de destino evita receber bytes
+    # comprimidos que ele não consegue decodificar.
+    headers.pop("accept-encoding", None)
 
     try:
         async with httpx.AsyncClient() as client:

--- a/src/backend/gateway/tests/test_proxy.py
+++ b/src/backend/gateway/tests/test_proxy.py
@@ -1,0 +1,46 @@
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+from starlette.requests import Request
+
+from gateway.proxy import proxy_request
+
+
+def _fake_request(headers: dict) -> Request:
+    raw_headers = [
+        (k.lower().encode(), v.encode()) for k, v in headers.items()
+    ]
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "headers": raw_headers,
+        "path": "/auth/login",
+        "query_string": b"",
+    }
+
+    async def receive():
+        return {"type": "http.request", "body": b"{}", "more_body": False}
+
+    return Request(scope, receive)
+
+
+def test_nao_repassa_accept_encoding_do_cliente():
+    """Regressão: repassar o Accept-Encoding do navegador (que anuncia
+    zstd/br) fazia o httpx do Gateway receber respostas comprimidas
+    que ele não sabe decodificar, corrompendo o JSON."""
+    request = _fake_request(
+        {"accept-encoding": "gzip, deflate, br, zstd", "content-type": "application/json"}
+    )
+
+    resposta_mock = AsyncMock()
+    resposta_mock.status_code = 200
+    resposta_mock.content = b'{"ok": true}'
+    resposta_mock.headers = {}
+
+    with patch(
+        "httpx.AsyncClient.request", AsyncMock(return_value=resposta_mock)
+    ) as mock_request:
+        asyncio.run(proxy_request("https://exemplo.com", "/auth/login", request))
+
+    headers_enviados = mock_request.call_args.kwargs["headers"]
+    assert "accept-encoding" not in headers_enviados


### PR DESCRIPTION
## Descrição

Login quebrando em produção:

```
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xb5 in position 1
  File "/app/gateway/routes.py", line 72, in login
    data = json.loads(response.body)
```

Causa: `proxy.py` repassa **todos** os headers da request original pro serviço de destino, inclusive o `Accept-Encoding` do navegador (`gzip, deflate, br, zstd`). O Fly.io comprime a resposta do `auth` com zstd por causa disso — mas o `httpx` do Gateway não tem decoder de zstd instalado, então `response.content` fica com os bytes comprimidos crus, e o `json.loads()` quebra.

`registrar` nunca quebrou porque só repassa a resposta crua pro navegador (que sabe descomprimir zstd sozinho); só `login`/`refresh` quebram porque precisam ler o JSON no meio do caminho pra extrair os tokens e setar os cookies httpOnly.

## O que mudou

- `proxy.py`: remove `Accept-Encoding` do cliente antes de repassar a request — deixa o `httpx` negociar sua própria compressão (que ele sabe decodificar).
- Teste de regressão garantindo que o header não é mais repassado.

## Já aplicado

Nada em produção ainda — esse fix só via deploy normal depois do merge.

## Como testar

Mergear, aguardar o deploy do backend, e tentar login em `https://movecity-frontend.vercel.app/login`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Jff434FipizyJUdsmiYtf