### PR TITLE
feat: links de navegação entre login e cadastro

### DIFF
--- a/src/frontend/app/cadastro/__tests__/page.test.tsx
+++ b/src/frontend/app/cadastro/__tests__/page.test.tsx
@@ -99,4 +99,10 @@ describe("Cadastro", () => {
     });
     expect(global.fetch).not.toHaveBeenCalled();
   });
+
+  it("exibe link para a página de login", () => {
+    render(<Cadastro />);
+    const link = screen.getByRole("link", { name: "Realizar login" });
+    expect(link).toHaveAttribute("href", "/login");
+  });
 });

--- a/src/frontend/app/cadastro/page.tsx
+++ b/src/frontend/app/cadastro/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { FormEvent, useState } from "react";
+import Link from "next/link";
 import { registrarUsuario, RegistroError } from "@/lib/api";
 
 const SENHA_REGEX = /^(?=.*[A-Za-z])(?=.*\d).{8,}$/;
@@ -136,6 +137,10 @@ export default function Cadastro() {
           <button type="submit" disabled={enviando}>
             {enviando ? "Cadastrando..." : "Cadastrar"}
           </button>
+
+          <p className="link-alternativo">
+            Já possui conta? <Link href="/login">Realizar login</Link>
+          </p>
         </form>
       </main>
 

--- a/src/frontend/app/globals.css
+++ b/src/frontend/app/globals.css
@@ -149,3 +149,14 @@ footer {
   opacity: 0.6;
   cursor: not-allowed;
 }
+
+.link-alternativo {
+  text-align: center;
+  font-size: 0.9rem;
+  color: #555;
+}
+
+.link-alternativo a {
+  color: #2c3e50;
+  font-weight: 600;
+}

--- a/src/frontend/app/login/__tests__/page.test.tsx
+++ b/src/frontend/app/login/__tests__/page.test.tsx
@@ -85,6 +85,12 @@ describe("Login", () => {
     });
   });
 
+  it("exibe link para a página de cadastro", () => {
+    render(<Login />);
+    const link = screen.getByRole("link", { name: "Cadastre-se" });
+    expect(link).toHaveAttribute("href", "/cadastro");
+  });
+
   it("bloqueia envio quando os campos não são preenchidos", async () => {
     render(<Login />);
     preencherFormulario({ email: "", senha: "" });

--- a/src/frontend/app/login/page.tsx
+++ b/src/frontend/app/login/page.tsx
@@ -2,6 +2,7 @@
 
 import { FormEvent, useState } from "react";
 import { useRouter } from "next/navigation";
+import Link from "next/link";
 import { loginUsuario, LoginError } from "@/lib/api";
 
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
@@ -102,6 +103,10 @@ export default function Login() {
           <button type="submit" disabled={enviando}>
             {enviando ? "Entrando..." : "Entrar"}
           </button>
+
+          <p className="link-alternativo">
+            Ainda não tem conta? <Link href="/cadastro">Cadastre-se</Link>
+          </p>
         </form>
       </main>
 


### PR DESCRIPTION
## Descrição

Closes #83

Hoje `/login` e `/cadastro` eram ilhas isoladas — sem link de uma pra outra.

## O que mudou

- `/login`: "Ainda não tem conta? **Cadastre-se**" → `/cadastro`
- `/cadastro`: "Já possui conta? **Realizar login**" → `/login`
- Estilo básico (`.link-alternativo`) no `globals.css`
- Testes novos garantindo os links e o `href` corretos

## Como testar

`https://movecity-frontend.vercel.app/login` e `/cadastro`, depois de mergear e o deploy rodar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Jff434FipizyJUdsmiYtf